### PR TITLE
实现 B 站原生投屏接收端（NVA / NirvanaControl）

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { initKeyboardNav, setFocus, onFocusChange } from './hooks/useFocus';
-import { getNavInfo } from './api/client';
+import { castAck, castSubscribe, getNavInfo } from './api/client';
 import { storage } from './utils/storage';
 import SidebarItem from './components/SidebarItem';
 
@@ -82,6 +82,7 @@ export default function App() {
   const [showLogin, setShowLogin] = useState(false);
   const [toast, setToast] = useState('');
   const [refreshKey, setRefreshKey] = useState(0);
+  const pendingCastAckRef = useRef(null);
 
   useEffect(() => {
     initKeyboardNav();
@@ -92,6 +93,63 @@ export default function App() {
     }
     setTimeout(() => setFocus('content-0-0'), 500);
   }, []);
+
+  useEffect(() => {
+    const unsubscribe = castSubscribe(async (event) => {
+      if (!event || event.kind !== 'command' || !event.command) return;
+      const command = event.command;
+
+      if (command.type === 'play') {
+        pendingCastAckRef.current = command;
+        if (command.contentType === 'live') {
+          setPlayerVideo(null);
+          setLiveRoom({
+            roomid: command.roomId,
+            title: command.title || '投屏直播',
+            owner: { name: '' },
+          });
+        } else {
+          setLiveRoom(null);
+          setPlayerVideo({
+            aid: command.aid,
+            bvid: command.bvid,
+            cid: command.cid,
+            epid: command.epid,
+            title: command.title || '投屏视频',
+            owner: { name: '' },
+            fromCast: true,
+          });
+        }
+        return;
+      }
+
+      if (command.type === 'stop') {
+        window.dispatchEvent(new CustomEvent('bili-cast-command', { detail: command }));
+        setPlayerVideo(null);
+        setLiveRoom(null);
+        return;
+      }
+
+      window.dispatchEvent(new CustomEvent('bili-cast-command', { detail: command }));
+    }, (err) => {
+      console.error('Cast subscribe error:', err);
+    });
+
+    return () => unsubscribe?.();
+  }, []);
+
+  useEffect(() => {
+    const pending = pendingCastAckRef.current;
+    if (!pending) return;
+    if ((pending.contentType === 'video' && playerVideo) || (pending.contentType === 'live' && liveRoom)) {
+      castAck({
+        accepted: true,
+        command: pending,
+        at: Date.now(),
+      }).catch(() => {});
+      pendingCastAckRef.current = null;
+    }
+  }, [playerVideo, liveRoom]);
 
   useEffect(() => {
     const handleBack = () => {
@@ -182,7 +240,7 @@ export default function App() {
         {toast && <div className="toast">{toast}</div>}
       </div>
 
-      {playerVideo && <PlayerPage key={playerVideo.bvid} video={playerVideo} onBack={() => setPlayerVideo(null)} onPlayNext={(v) => setPlayerVideo(v)} />}
+      {playerVideo && <PlayerPage key={playerVideo.bvid || playerVideo.aid || playerVideo.cid} video={playerVideo} onBack={() => setPlayerVideo(null)} onPlayNext={(v) => setPlayerVideo(v)} />}
       {liveRoom && <LivePlayerPage key={liveRoom.roomid} room={liveRoom} onBack={() => setLiveRoom(null)} />}
 
       {showLogin && (

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -118,6 +118,7 @@ export default function App() {
             title: command.title || '投屏视频',
             owner: { name: '' },
             fromCast: true,
+            progress: Math.max(0, Number(command.seekTs || 0)),
           });
         }
         return;

--- a/app/src/api/client.js
+++ b/app/src/api/client.js
@@ -118,6 +118,66 @@ export async function rawFetch(url, options) {
   return proxyFetchRaw(url, options);
 }
 
+function lunaRequest(method, parameters, subscribe, handlers) {
+  handlers = handlers || {};
+  return new Promise(function(resolve, reject) {
+    if (!hasLunaService()) {
+      if (handlers.allowMissing) { resolve(null); return; }
+      reject(new Error('Luna not available'));
+      return;
+    }
+
+    window.webOS.service.request(SERVICE_URI, {
+      method: method,
+      subscribe: !!subscribe,
+      parameters: parameters || {},
+      onSuccess: function(res) {
+        if (handlers.onSuccess) handlers.onSuccess(res);
+        resolve(res);
+      },
+      onFailure: function(err) {
+        if (handlers.onFailure) handlers.onFailure(err);
+        reject(new Error(err.errorText || err.error || (method + ' failed')));
+      },
+    });
+  });
+}
+
+export function castSubscribe(onEvent, onFailure) {
+  if (!hasLunaService()) return function () {};
+
+  let cancelled = false;
+  window.webOS.service.request(SERVICE_URI, {
+    method: 'castSubscribe',
+    subscribe: true,
+    parameters: { subscribe: true },
+    onSuccess: function(res) {
+      if (!cancelled && res?.event && onEvent) onEvent(res.event, res.status);
+    },
+    onFailure: function(err) {
+      if (!cancelled && onFailure) onFailure(err);
+    }
+  });
+
+  return function () { cancelled = true; };
+}
+
+export async function castAck(payload) {
+  return lunaRequest('castAck', payload || {}, false, { allowMissing: true });
+}
+
+export async function castReportState(payload) {
+  return lunaRequest('castReportState', payload || {}, false, { allowMissing: true });
+}
+
+export async function castReportProgress(payload) {
+  return lunaRequest('castReportProgress', payload || {}, false, { allowMissing: true });
+}
+
+export async function castGetStatus() {
+  return lunaRequest('castGetStatus', {}, false, { allowMissing: true });
+}
+
 // ============ Login ============
 
 export async function qrCodeGenerate() {
@@ -150,14 +210,24 @@ export async function getRanking(rid, type) {
   return wbiFetch('/x/web-interface/ranking/v2', { rid: rid || 0, type: type || 'all' });
 }
 
-export async function getVideoInfo(bvid) {
-  return wbiFetch('/x/web-interface/view', { bvid: bvid });
+export async function getVideoInfo(video) {
+  if (typeof video === 'string') {
+    return wbiFetch('/x/web-interface/view', { bvid: video });
+  }
+  video = video || {};
+  if (video.bvid) return wbiFetch('/x/web-interface/view', { bvid: video.bvid });
+  if (video.aid) return wbiFetch('/x/web-interface/view', { aid: video.aid });
+  throw new Error('Missing video identifier');
 }
 
-export async function getPlayUrl(bvid, cid, qn) {
-  return wbiFetch('/x/player/playurl', {
-    bvid: bvid, cid: cid, qn: qn || 80, fnval: 4048, fnver: 0, fourk: 1, platform: 'pc',
-  });
+export async function getPlayUrl(videoOrBvid, cid, qn) {
+  var payload = {
+    cid: cid, qn: qn || 80, fnval: 4048, fnver: 0, fourk: 1, platform: 'pc',
+  };
+  if (typeof videoOrBvid === 'string') payload.bvid = videoOrBvid;
+  else if (videoOrBvid?.bvid) payload.bvid = videoOrBvid.bvid;
+  else if (videoOrBvid?.aid) payload.avid = videoOrBvid.aid;
+  return wbiFetch('/x/player/playurl', payload);
 }
 
 // Partition/region

--- a/app/src/player/LivePlayerPage.jsx
+++ b/app/src/player/LivePlayerPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { getLiveStreamUrl } from '../api/client';
+import { getLiveStreamUrl, castReportState } from '../api/client';
 import { storage } from '../utils/storage';
 import { setCustomKeyHandler } from '../hooks/useFocus';
 
@@ -12,6 +12,7 @@ export default function LivePlayerPage({ room, onBack }) {
   useEffect(() => {
     async function load() {
       try {
+        castReportState({ playState: 'loading' }).catch(() => {});
         const hlsUrl = await getLiveStreamUrl(room.roomid);
         if (!hlsUrl || !videoRef.current) return;
 
@@ -25,17 +26,46 @@ export default function LivePlayerPage({ room, onBack }) {
         videoRef.current.src = proxied;
         videoRef.current.play();
         setLoading(false);
+        castReportState({ playState: 'playing' }).catch(() => {});
 
         // Hide info after 3s
         infoTimer.current = setTimeout(() => setShowInfo(false), 3000);
       } catch (err) {
         console.error('Live stream error:', err);
         setLoading(false);
+        castReportState({ playState: 'error', error: err?.message || 'live-load-failed' }).catch(() => {});
       }
     }
     load();
-    return () => { if (infoTimer.current) clearTimeout(infoTimer.current); };
+    return () => {
+      if (infoTimer.current) clearTimeout(infoTimer.current);
+      castReportState({ playState: 'stop' }).catch(() => {});
+    };
   }, [room.roomid]);
+
+  useEffect(() => {
+    const handleCastCommand = (event) => {
+      const command = event.detail;
+      if (!command) return;
+      if (command.type === 'stop') {
+        onBack?.();
+        return;
+      }
+      if (!videoRef.current) return;
+      if (command.type === 'pause') {
+        videoRef.current.pause();
+        castReportState({ playState: 'paused' }).catch(() => {});
+        return;
+      }
+      if (command.type === 'resume') {
+        videoRef.current.play();
+        castReportState({ playState: 'playing' }).catch(() => {});
+      }
+    };
+
+    window.addEventListener('bili-cast-command', handleCastCommand);
+    return () => window.removeEventListener('bili-cast-command', handleCastCommand);
+  }, [onBack]);
 
   // Key handler
   useEffect(() => {

--- a/app/src/player/PlayerPage.jsx
+++ b/app/src/player/PlayerPage.jsx
@@ -30,6 +30,29 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
   const cidRef = useRef(null);
   const startTimeRef = useRef(Date.now());
 
+  const pendingSeekRef = useRef(null);
+
+  const queueOrApplySeek = useCallback((seekSec) => {
+    const target = Math.max(0, Number(seekSec) || 0);
+    if (!videoRef.current) return;
+    const canSeekNow = Number.isFinite(videoRef.current.duration) && videoRef.current.duration > 0;
+    if (canSeekNow) {
+      const max = Math.max(0, (videoRef.current.duration || 0) - 0.2);
+      videoRef.current.currentTime = Math.min(target, max || target);
+      pendingSeekRef.current = null;
+      return;
+    }
+    pendingSeekRef.current = target;
+  }, []);
+
+  const flushPendingSeek = useCallback(() => {
+    if (pendingSeekRef.current == null || !videoRef.current) return;
+    if (!(Number.isFinite(videoRef.current.duration) && videoRef.current.duration > 0)) return;
+    const max = Math.max(0, (videoRef.current.duration || 0) - 0.2);
+    videoRef.current.currentTime = Math.min(pendingSeekRef.current, max || pendingSeekRef.current);
+    pendingSeekRef.current = null;
+  }, []);
+
   const CONTROLS = ['play', 'danmaku', 'quality'];
 
   // Initialize Shaka Player
@@ -90,8 +113,8 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
       await player.load(mpdUrl);
       URL.revokeObjectURL(mpdUrl);
 
-      if (video.progress && video.progress > 0 && video.progress < (dash.duration || 9999) - 10) {
-        videoRef.current.currentTime = video.progress;
+      if (video.progress && video.progress > 0) {
+        queueOrApplySeek(video.progress);
       }
 
       videoRef.current.play();
@@ -117,7 +140,7 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
       setLoading(false);
       castReportState({ playState: 'error', error: err?.message || 'load-failed' }).catch(() => {});
     }
-  }, [video]);
+  }, [video, queueOrApplySeek]);
 
   function buildMPD(dash) {
     const duration = dash.duration || 0;
@@ -184,6 +207,9 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
       setPlaying(true);
       castReportState({ playState: 'playing' }).catch(() => {});
     };
+    const handleLoadedMetadata = () => flushPendingSeek();
+    const handleCanPlay = () => flushPendingSeek();
+
     const handlePause = () => {
       if (!ended) castReportState({ playState: 'paused' }).catch(() => {});
       setPlaying(false);
@@ -191,11 +217,15 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
 
     el.addEventListener('play', handlePlay);
     el.addEventListener('pause', handlePause);
+    el.addEventListener('loadedmetadata', handleLoadedMetadata);
+    el.addEventListener('canplay', handleCanPlay);
     return () => {
       el.removeEventListener('play', handlePlay);
       el.removeEventListener('pause', handlePause);
+      el.removeEventListener('loadedmetadata', handleLoadedMetadata);
+      el.removeEventListener('canplay', handleCanPlay);
     };
-  }, [ended]);
+  }, [ended, flushPendingSeek]);
 
   useEffect(() => {
     return () => {
@@ -309,7 +339,7 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
         return;
       }
       if (command.type === 'seek') {
-        videoRef.current.currentTime = Math.max(0, command.positionSec || 0);
+        queueOrApplySeek(command.positionSec);
         castReportProgress({
           duration: Math.floor(videoRef.current.duration || 0),
           position: Math.floor(videoRef.current.currentTime || 0),
@@ -328,7 +358,7 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
 
     window.addEventListener('bili-cast-command', handleCastCommand);
     return () => window.removeEventListener('bili-cast-command', handleCastCommand);
-  }, [onBack]);
+  }, [onBack, queueOrApplySeek]);
 
   // ========== Keyboard handler ==========
   useEffect(() => {

--- a/app/src/player/PlayerPage.jsx
+++ b/app/src/player/PlayerPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { getPlayUrl, getDanmaku, getVideoInfo, reportHeartbeat, getRelated } from '../api/client';
+import { getPlayUrl, getDanmaku, getVideoInfo, reportHeartbeat, getRelated, castReportProgress, castReportState } from '../api/client';
 import { formatDuration, QUALITY_MAP } from '../utils/format';
 import { storage } from '../utils/storage';
 import { setCustomKeyHandler } from '../hooks/useFocus';
@@ -50,20 +50,22 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
   }, []);
 
   const loadVideo = useCallback(async (player) => {
-    if (!video?.bvid) return;
+    if (!video?.bvid && !video?.aid) return;
     setLoading(true);
+    castReportState({ playState: 'loading' }).catch(() => {});
     try {
       let cid = video.cid;
       if (!cid) {
-        const info = await getVideoInfo(video.bvid);
+        const info = await getVideoInfo(video);
         cid = info?.data?.cid;
         if (info?.data?.title) setVideoTitle(info.data.title);
+        if (!video.bvid && info?.data?.bvid) video.bvid = info.data.bvid;
       }
       if (!cid) return;
       cidRef.current = cid;
 
       const settings = storage.getSettings();
-      const res = await getPlayUrl(video.bvid, cid, settings.quality || 80);
+      const res = await getPlayUrl(video, cid, settings.quality || 80);
       const dash = res?.data?.dash;
       if (!dash) return;
 
@@ -95,12 +97,14 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
       videoRef.current.play();
       setPlaying(true);
       setLoading(false);
+      castReportState({ playState: 'playing' }).catch(() => {});
 
       videoRef.current.addEventListener('ended', () => {
         setEnded(true);
         setShowControls(true);
         setFocusArea('endscreen');
         setFocusIdx(0);
+        castReportState({ playState: 'end' }).catch(() => {});
       });
 
       try { setDanmakus(await getDanmaku(cid)); } catch {}
@@ -111,6 +115,7 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
     } catch (err) {
       console.error('Load video error:', err);
       setLoading(false);
+      castReportState({ playState: 'error', error: err?.message || 'load-failed' }).catch(() => {});
     }
   }, [video]);
 
@@ -158,11 +163,44 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
   useEffect(() => {
     timeUpdateRef.current = setInterval(() => {
       if (videoRef.current) {
-        setCurrentTime(videoRef.current.currentTime);
-        setDuration(videoRef.current.duration || 0);
+        const nextCurrentTime = videoRef.current.currentTime;
+        const nextDuration = videoRef.current.duration || 0;
+        setCurrentTime(nextCurrentTime);
+        setDuration(nextDuration);
+        castReportProgress({
+          duration: Math.floor(nextDuration),
+          position: Math.floor(nextCurrentTime),
+        }).catch(() => {});
       }
     }, 500);
     return () => clearInterval(timeUpdateRef.current);
+  }, []);
+
+  useEffect(() => {
+    const el = videoRef.current;
+    if (!el) return;
+
+    const handlePlay = () => {
+      setPlaying(true);
+      castReportState({ playState: 'playing' }).catch(() => {});
+    };
+    const handlePause = () => {
+      if (!ended) castReportState({ playState: 'paused' }).catch(() => {});
+      setPlaying(false);
+    };
+
+    el.addEventListener('play', handlePlay);
+    el.addEventListener('pause', handlePause);
+    return () => {
+      el.removeEventListener('play', handlePlay);
+      el.removeEventListener('pause', handlePause);
+    };
+  }, [ended]);
+
+  useEffect(() => {
+    return () => {
+      castReportState({ playState: 'stop' }).catch(() => {});
+    };
   }, []);
 
   // Heartbeat
@@ -226,12 +264,12 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
 
   // Change quality
   const changeQuality = useCallback(async (qn) => {
-    if (!video?.bvid || !shakaRef.current) return;
+    if ((!video?.bvid && !video?.aid) || !shakaRef.current) return;
     setCurrentQuality(qn);
     storage.setSettings({ ...storage.getSettings(), quality: qn });
     try {
       let cid = video.cid || cidRef.current;
-      const res = await getPlayUrl(video.bvid, cid, qn);
+      const res = await getPlayUrl(video, cid, qn);
       const dash = res?.data?.dash;
       if (dash) {
         const pos = videoRef.current.currentTime;
@@ -248,6 +286,49 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
       console.error('Quality change error:', e);
     }
   }, [video]);
+
+  useEffect(() => {
+    storage.setSettings({ ...storage.getSettings(), danmaku: danmakuEnabled });
+  }, [danmakuEnabled]);
+
+  useEffect(() => {
+    const handleCastCommand = (event) => {
+      const command = event.detail;
+      if (!command || !videoRef.current) return;
+
+      if (command.type === 'pause') {
+        videoRef.current.pause();
+        setPlaying(false);
+        castReportState({ playState: 'paused' }).catch(() => {});
+        return;
+      }
+      if (command.type === 'resume') {
+        videoRef.current.play();
+        setPlaying(true);
+        castReportState({ playState: 'playing' }).catch(() => {});
+        return;
+      }
+      if (command.type === 'seek') {
+        videoRef.current.currentTime = Math.max(0, command.positionSec || 0);
+        castReportProgress({
+          duration: Math.floor(videoRef.current.duration || 0),
+          position: Math.floor(videoRef.current.currentTime || 0),
+        }).catch(() => {});
+        return;
+      }
+      if (command.type === 'switchDanmaku') {
+        setDanmakuEnabled(!!command.open);
+        return;
+      }
+      if (command.type === 'stop') {
+        videoRef.current.pause();
+        onBack?.();
+      }
+    };
+
+    window.addEventListener('bili-cast-command', handleCastCommand);
+    return () => window.removeEventListener('bili-cast-command', handleCastCommand);
+  }, [onBack]);
 
   // ========== Keyboard handler ==========
   useEffect(() => {
@@ -338,8 +419,13 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
           e.preventDefault();
           const btn = CONTROLS[focusIdx];
           if (btn === 'play') {
-            if (videoRef.current.paused) { videoRef.current.play(); setPlaying(true); }
-            else { videoRef.current.pause(); setPlaying(false); }
+            if (videoRef.current.paused) {
+              videoRef.current.play(); setPlaying(true);
+              castReportState({ playState: 'playing' }).catch(() => {});
+            } else {
+              videoRef.current.pause(); setPlaying(false);
+              castReportState({ playState: 'paused' }).catch(() => {});
+            }
           } else if (btn === 'danmaku') {
             setDanmakuEnabled(prev => !prev);
           } else if (btn === 'quality') {

--- a/package.json
+++ b/package.json
@@ -2,5 +2,8 @@
   "dependencies": {
     "ssh2": "^1.17.0",
     "ws": "^8.20.0"
+  },
+  "scripts": {
+    "test": "node --test service/com.biliwebos.app.service/test/*.test.js"
   }
 }

--- a/service/com.biliwebos.app.service/cast/castController.js
+++ b/service/com.biliwebos.app.service/cast/castController.js
@@ -1,0 +1,174 @@
+var EventEmitter = require('events');
+
+var PLAY_STATE_MAP = {
+  idle: 0,
+  loading: 3,
+  playing: 4,
+  paused: 5,
+  end: 6,
+  stop: 7,
+  error: 8,
+};
+
+function safeJsonParse(raw) {
+  if (!raw) return {};
+  try { return JSON.parse(raw); } catch (e) { return {}; }
+}
+
+function toNumber(value) {
+  var n = Number(value);
+  return isFinite(n) ? n : 0;
+}
+
+function normalizePlayPayload(payload) {
+  payload = payload || {};
+  var roomId = toNumber(payload.roomId || payload.room_id);
+  if (roomId > 0) {
+    return {
+      type: 'play',
+      contentType: 'live',
+      roomId: roomId,
+      title: payload.title || '',
+    };
+  }
+
+  var aid = toNumber(payload.aid);
+  var cid = toNumber(payload.cid);
+  var epid = toNumber(payload.epid || payload.epId);
+  var bvid = payload.bvid || '';
+  if (!aid && !cid && !epid && !bvid) return null;
+
+  return {
+    type: 'play',
+    contentType: 'video',
+    aid: aid || undefined,
+    cid: cid || undefined,
+    epid: epid || undefined,
+    bvid: bvid || undefined,
+    title: payload.title || '',
+  };
+}
+
+function parsePlayUrlPayload(payload) {
+  if (!payload || !payload.url) return null;
+  try {
+    var parsed = new URL(payload.url);
+    var ext = parsed.searchParams.get('nva_ext');
+    if (!ext) return null;
+    var decoded = safeJsonParse(decodeURIComponent(ext));
+    return normalizePlayPayload(decoded.content || decoded);
+  } catch (e) {
+    return null;
+  }
+}
+
+function CastController() {
+  this.sessions = new Map();
+  this.emitter = new EventEmitter();
+  this.status = {
+    sessionId: null,
+    deviceIp: null,
+    httpPort: null,
+    activeContent: null,
+    playState: 'idle',
+    progress: 0,
+    duration: 0,
+    lastCommandAt: 0,
+    lastError: null,
+  };
+}
+
+CastController.prototype.attachSession = function (session) {
+  this.sessions.set(session.id, session);
+  this.status.sessionId = session.id;
+};
+
+CastController.prototype.detachSession = function (sessionId) {
+  this.sessions.delete(sessionId);
+  if (this.status.sessionId === sessionId) this.status.sessionId = null;
+};
+
+CastController.prototype.onIntent = function (listener) {
+  this.emitter.on('intent', listener);
+  return this;
+};
+
+CastController.prototype.emitIntent = function (intent) {
+  this.emitter.emit('intent', intent);
+};
+
+CastController.prototype.handleCommand = function (sessionId, action, rawBody) {
+  var payload = safeJsonParse(rawBody);
+  var intent = null;
+
+  this.status.sessionId = sessionId;
+  this.status.lastCommandAt = Date.now();
+
+  if (action === 'Play') {
+    intent = normalizePlayPayload(payload);
+    if (intent) this.status.activeContent = intent;
+  } else if (action === 'PlayUrl') {
+    intent = parsePlayUrlPayload(payload);
+    if (intent) this.status.activeContent = intent;
+  } else if (action === 'Pause') {
+    intent = { type: 'pause' };
+  } else if (action === 'Resume') {
+    intent = { type: 'resume' };
+  } else if (action === 'Stop') {
+    intent = { type: 'stop' };
+    this.status.playState = 'stop';
+  } else if (action === 'Seek') {
+    intent = { type: 'seek', positionSec: toNumber(payload.seekTs || payload.position || payload.positionSec) };
+  } else if (action === 'SwitchDanmaku') {
+    intent = { type: 'switchDanmaku', open: !!payload.open };
+  }
+
+  if (intent) this.emitIntent(intent);
+  return intent;
+};
+
+CastController.prototype.reportState = function (payload) {
+  payload = payload || {};
+  this.status.playState = payload.playState || this.status.playState;
+  this.status.lastError = payload.error || null;
+
+  var numericState = PLAY_STATE_MAP[this.status.playState];
+  if (typeof numericState === 'number') {
+    this.sessions.forEach(function (session) {
+      session.sendCommand('OnPlayState', { playState: numericState });
+    });
+  }
+};
+
+CastController.prototype.reportProgress = function (payload) {
+  payload = payload || {};
+  this.status.duration = toNumber(payload.duration);
+  this.status.progress = toNumber(payload.position);
+
+  this.sessions.forEach(function (session) {
+    session.sendCommand('OnProgress', {
+      duration: payload.duration || 0,
+      position: payload.position || 0,
+    });
+  });
+};
+
+CastController.prototype.ack = function (payload) {
+  payload = payload || {};
+  this.status.lastAckAt = Date.now();
+  this.status.lastAck = payload;
+};
+
+CastController.prototype.setNetworkInfo = function (ip, httpPort) {
+  this.status.deviceIp = ip;
+  this.status.httpPort = httpPort;
+};
+
+CastController.prototype.getStatus = function () {
+  return JSON.parse(JSON.stringify(this.status));
+};
+
+module.exports = {
+  CastController: CastController,
+  PLAY_STATE_MAP: PLAY_STATE_MAP,
+};

--- a/service/com.biliwebos.app.service/cast/castController.js
+++ b/service/com.biliwebos.app.service/cast/castController.js
@@ -22,6 +22,7 @@ function toNumber(value) {
 
 function normalizePlayPayload(payload) {
   payload = payload || {};
+  var seekTs = toNumber(payload.seekTs || payload.seek_ts || payload.position || payload.positionSec);
   var roomId = toNumber(payload.roomId || payload.room_id);
   if (roomId > 0) {
     return {
@@ -29,6 +30,7 @@ function normalizePlayPayload(payload) {
       contentType: 'live',
       roomId: roomId,
       title: payload.title || '',
+      seekTs: seekTs,
     };
   }
 
@@ -46,6 +48,7 @@ function normalizePlayPayload(payload) {
     epid: epid || undefined,
     bvid: bvid || undefined,
     title: payload.title || '',
+    seekTs: seekTs,
   };
 }
 

--- a/service/com.biliwebos.app.service/cast/deviceProfile.js
+++ b/service/com.biliwebos.app.service/cast/deviceProfile.js
@@ -1,0 +1,160 @@
+var crypto = require('crypto');
+
+var SERVER_NAME = 'Linux/3.0.0, UPnP/1.0, Platinum/1.0.5.13';
+
+function xmlEscape(str) {
+  return String(str || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function formatHttpDate(date) {
+  return new Date(date || Date.now()).toUTCString();
+}
+
+function randomUuid() {
+  return crypto.randomBytes(18).toString('hex').toUpperCase().slice(0, 35);
+}
+
+function createDeviceProfile(options) {
+  options = options || {};
+  return {
+    uuid: options.uuid || randomUuid(),
+    ip: options.ip || '127.0.0.1',
+    httpPort: options.httpPort || 9958,
+    friendlyName: options.friendlyName || '我的小电视',
+    manufacturer: 'Bilibili Inc.',
+    manufacturerURL: 'https://www.bilibili.com/',
+    modelDescription: '云视听小电视',
+    modelName: 'BRAVIA 4K 2015',
+    modelNumber: '1024',
+    modelURL: 'https://app.bilibili.com/',
+    serialNumber: '1024',
+    brandName: 'ATV',
+    hostVersion: '25',
+    ottVersion: '105500',
+    channelName: 'master',
+    capability: '255',
+    serverName: SERVER_NAME,
+  };
+}
+
+function getLocation(profile) {
+  return 'http://' + profile.ip + ':' + profile.httpPort + '/description.xml';
+}
+
+function renderDescriptionXml(profile) {
+  return [
+    '<root xmlns:dlna="urn:schemas-dlna-org:device-1-0" xmlns="urn:schemas-upnp-org:device-1-0">',
+    '<specVersion><major>1</major><minor>0</minor></specVersion>',
+    '<device>',
+    '<deviceType>urn:schemas-upnp-org:device:MediaRenderer:1</deviceType>',
+    '<UDN>uuid:' + xmlEscape(profile.uuid) + '</UDN>',
+    '<friendlyName>' + xmlEscape(profile.friendlyName) + '</friendlyName>',
+    '<manufacturer>' + xmlEscape(profile.manufacturer) + '</manufacturer>',
+    '<manufacturerURL>' + xmlEscape(profile.manufacturerURL) + '</manufacturerURL>',
+    '<modelDescription>' + xmlEscape(profile.modelDescription) + '</modelDescription>',
+    '<modelName>' + xmlEscape(profile.modelName) + '</modelName>',
+    '<modelNumber>' + xmlEscape(profile.modelNumber) + '</modelNumber>',
+    '<modelURL>' + xmlEscape(profile.modelURL) + '</modelURL>',
+    '<serialNumber>' + xmlEscape(profile.serialNumber) + '</serialNumber>',
+    '<X_brandName>' + xmlEscape(profile.brandName) + '</X_brandName>',
+    '<hostVersion>' + xmlEscape(profile.hostVersion) + '</hostVersion>',
+    '<ottVersion>' + xmlEscape(profile.ottVersion) + '</ottVersion>',
+    '<channelName>' + xmlEscape(profile.channelName) + '</channelName>',
+    '<capability>' + xmlEscape(profile.capability) + '</capability>',
+    '<dlna:X_DLNADOC xmlns:dlna="urn:schemas-dlna-org:device-1-0">DMR-1.50</dlna:X_DLNADOC>',
+    '<dlna:X_DLNACAP xmlns:dlna="urn:schemas-dlna-org:device-1-0">playcontainer-1-0</dlna:X_DLNACAP>',
+    '<serviceList>',
+    '<service>',
+    '<serviceType>urn:schemas-upnp-org:service:AVTransport:1</serviceType>',
+    '<serviceId>urn:upnp-org:serviceId:AVTransport</serviceId>',
+    '<controlURL>AVTransport/action</controlURL>',
+    '<eventSubURL>AVTransport/event</eventSubURL>',
+    '<SCPDURL>dlna/AVTransport.xml</SCPDURL>',
+    '</service>',
+    '<service>',
+    '<serviceType>urn:app-bilibili-com:service:NirvanaControl:3</serviceType>',
+    '<serviceId>urn:app-bilibili-com:serviceId:NirvanaControl</serviceId>',
+    '<controlURL>NirvanaControl/action</controlURL>',
+    '<eventSubURL>NirvanaControl/event</eventSubURL>',
+    '<SCPDURL>dlna/NirvanaControl.xml</SCPDURL>',
+    '</service>',
+    '</serviceList>',
+    '</device>',
+    '</root>'
+  ].join('');
+}
+
+function renderAvTransportScpd() {
+  return [
+    '<?xml version="1.0"?>',
+    '<scpd xmlns="urn:schemas-upnp-org:service-1-0">',
+    '<specVersion><major>1</major><minor>0</minor></specVersion>',
+    '<actionList>',
+    '<action><name>Play</name></action>',
+    '<action><name>Pause</name></action>',
+    '<action><name>Stop</name></action>',
+    '<action><name>Seek</name></action>',
+    '</actionList>',
+    '</scpd>'
+  ].join('');
+}
+
+function renderNirvanaScpd() {
+  return '<actionList><action><name>GetAppInfo</name><argumentList></argumentList></action></actionList>';
+}
+
+function buildNotify(profile, nt, usn) {
+  return [
+    'NOTIFY * HTTP/1.1',
+    'HOST: 239.255.255.250:1900',
+    'LOCATION: ' + getLocation(profile),
+    'CACHE-CONTROL: max-age=30',
+    'SERVER: ' + profile.serverName,
+    'NTS: ssdp:alive',
+    'USN: ' + usn,
+    'NT: ' + nt,
+    '',
+    ''
+  ].join('\r\n');
+}
+
+function getSsdpNotifyPackets(profile) {
+  var uuid = 'uuid:' + profile.uuid;
+  return [
+    buildNotify(profile, 'upnp:rootdevice', uuid + '::upnp:rootdevice'),
+    buildNotify(profile, 'urn:schemas-upnp-org:device:MediaRenderer:1', uuid + '::urn:schemas-upnp-org:device:MediaRenderer:1'),
+    buildNotify(profile, 'urn:schemas-upnp-org:service:AVTransport:1', uuid + '::urn:schemas-upnp-org:service:AVTransport:1'),
+    buildNotify(profile, 'urn:app-bilibili-com:service:NirvanaControl:3', uuid + '::urn:app-bilibili-com:service:NirvanaControl:3')
+  ];
+}
+
+function getSsdpSearchResponse(profile, st) {
+  return [
+    'HTTP/1.1 200 OK',
+    'LOCATION: ' + getLocation(profile),
+    'CACHE-CONTROL: max-age=30',
+    'SERVER: ' + profile.serverName,
+    'EXT:',
+    'BOOTID.UPNP.ORG: 1669443520',
+    'CONFIGID.UPNP.ORG: 10177363',
+    'USN: uuid:atvbilibili&' + profile.uuid + '::upnp:rootdevice',
+    'ST: upnp:rootdevice',
+    'DATE: ' + formatHttpDate(),
+    '',
+    ''
+  ].join('\r\n');
+}
+
+module.exports = {
+  createDeviceProfile: createDeviceProfile,
+  renderDescriptionXml: renderDescriptionXml,
+  renderAvTransportScpd: renderAvTransportScpd,
+  renderNirvanaScpd: renderNirvanaScpd,
+  getSsdpNotifyPackets: getSsdpNotifyPackets,
+  getSsdpSearchResponse: getSsdpSearchResponse,
+  getLocation: getLocation,
+};

--- a/service/com.biliwebos.app.service/cast/nvaSession.js
+++ b/service/com.biliwebos.app.service/cast/nvaSession.js
@@ -1,0 +1,201 @@
+function readUInt32BE(buffer, offset) {
+  return buffer.readUInt32BE(offset);
+}
+
+function writeUInt32BE(value) {
+  var buf = Buffer.alloc(4);
+  buf.writeUInt32BE(value >>> 0, 0);
+  return buf;
+}
+
+function decodeFrame(buffer) {
+  var typeByte = buffer[0];
+  var paramCount = buffer[1];
+  var version = readUInt32BE(buffer, 2);
+  var frame = {
+    rawType: typeByte,
+    version: version,
+    paramCount: paramCount,
+    type: typeByte === 0xe0 ? 'command' : (typeByte === 0xc0 ? 'reply' : 'ping'),
+    command: '',
+    action: '',
+    body: '',
+  };
+
+  if (paramCount === 0) return frame;
+
+  var cursor = 6;
+  if (buffer.length > cursor) cursor += 1; // marker
+  var commandLength = buffer[cursor];
+  cursor += 1;
+  frame.command = buffer.subarray(cursor, cursor + commandLength).toString('utf8');
+  cursor += commandLength;
+
+  if (typeByte !== 0xe0 || paramCount === 1) return frame;
+
+  var actionLength = buffer[cursor];
+  cursor += 1;
+  frame.action = buffer.subarray(cursor, cursor + actionLength).toString('utf8');
+  cursor += actionLength;
+
+  if (paramCount === 3) {
+    var bodyLength = readUInt32BE(buffer, cursor);
+    cursor += 4;
+    frame.body = buffer.subarray(cursor, cursor + bodyLength).toString('utf8');
+  }
+
+  return frame;
+}
+
+function encodeEmptyReply(version) {
+  return Buffer.concat([
+    Buffer.from([0xc0, 0x00]),
+    writeUInt32BE(version)
+  ]);
+}
+
+function encodeJsonReply(version, content) {
+  var body = Buffer.from(JSON.stringify(content || {}));
+  return Buffer.concat([
+    Buffer.from([0xc0, 0x01]),
+    writeUInt32BE(version),
+    writeUInt32BE(body.length),
+    body
+  ]);
+}
+
+function encodeCommand(version, action, content) {
+  var command = Buffer.from('Command');
+  var actionBuf = Buffer.from(action || '');
+  var body = Buffer.from(JSON.stringify(content || {}));
+  return Buffer.concat([
+    Buffer.from([0xe0, 0x03]),
+    writeUInt32BE(version),
+    Buffer.from([0x01, command.length]),
+    command,
+    Buffer.from([actionBuf.length]),
+    actionBuf,
+    writeUInt32BE(body.length),
+    body
+  ]);
+}
+
+function encodePing(version) {
+  return Buffer.concat([
+    Buffer.from([0xe4, 0x00]),
+    writeUInt32BE(version)
+  ]);
+}
+
+function NvaSession(id, socket, onFrame, onClose) {
+  this.id = id;
+  this.socket = socket;
+  this.currentVersion = 1;
+  this.buffer = Buffer.alloc(0);
+  this.onFrame = onFrame;
+  this.onClose = onClose;
+  this.closed = false;
+  this.pingTimer = null;
+
+  var self = this;
+  socket.on('data', function (chunk) {
+    self.handleData(chunk);
+  });
+  socket.on('close', function () {
+    self.close();
+  });
+  socket.on('end', function () {
+    self.close();
+  });
+  socket.on('error', function () {
+    self.close();
+  });
+}
+
+NvaSession.prototype.startPing = function () {
+  var self = this;
+  if (self.pingTimer) clearInterval(self.pingTimer);
+  self.pingTimer = setInterval(function () {
+    if (!self.closed) self.sendPing();
+  }, 10000);
+};
+
+NvaSession.prototype.handleData = function (chunk) {
+  this.buffer = Buffer.concat([this.buffer, chunk]);
+  while (this.buffer.length >= 6) {
+    var typeByte = this.buffer[0];
+    var paramCount = this.buffer[1];
+    var total = 6;
+
+    if (paramCount === 0) {
+      total = 6;
+    } else if (typeByte === 0xc0) {
+      if (paramCount === 1) {
+        if (this.buffer.length < 10) return;
+        total = 10 + this.buffer.readUInt32BE(6);
+      } else {
+        total = 6;
+      }
+    } else {
+      if (this.buffer.length < 9) return;
+      var commandLength = this.buffer[7];
+      total = 8 + commandLength;
+      if (paramCount >= 2) {
+        if (this.buffer.length < total + 1) return;
+        var actionLength = this.buffer[total];
+        total += 1 + actionLength;
+      }
+      if (paramCount === 3) {
+        if (this.buffer.length < total + 4) return;
+        total += 4 + this.buffer.readUInt32BE(total);
+      }
+    }
+
+    if (this.buffer.length < total) return;
+    var frameBuffer = this.buffer.subarray(0, total);
+    this.buffer = this.buffer.subarray(total);
+    var frame = decodeFrame(frameBuffer);
+    this.currentVersion = Math.max(this.currentVersion, frame.version);
+    if (this.onFrame) this.onFrame(this, frame);
+  }
+};
+
+NvaSession.prototype.sendBuffer = function (buf) {
+  if (!this.closed) this.socket.write(buf);
+};
+
+NvaSession.prototype.sendEmpty = function () {
+  this.currentVersion += 1;
+  this.sendBuffer(encodeEmptyReply(this.currentVersion));
+};
+
+NvaSession.prototype.sendReply = function (content) {
+  this.currentVersion += 1;
+  this.sendBuffer(encodeJsonReply(this.currentVersion, content));
+};
+
+NvaSession.prototype.sendCommand = function (action, content) {
+  this.currentVersion += 1;
+  this.sendBuffer(encodeCommand(this.currentVersion, action, content));
+};
+
+NvaSession.prototype.sendPing = function () {
+  this.currentVersion += 1;
+  this.sendBuffer(encodePing(this.currentVersion));
+};
+
+NvaSession.prototype.close = function () {
+  if (this.closed) return;
+  this.closed = true;
+  if (this.pingTimer) clearInterval(this.pingTimer);
+  try { this.socket.destroy(); } catch (e) {}
+  if (this.onClose) this.onClose(this);
+};
+
+module.exports = {
+  decodeFrame: decodeFrame,
+  encodeEmptyReply: encodeEmptyReply,
+  encodeJsonReply: encodeJsonReply,
+  encodeCommand: encodeCommand,
+  NvaSession: NvaSession,
+};

--- a/service/com.biliwebos.app.service/cast/ssdpServer.js
+++ b/service/com.biliwebos.app.service/cast/ssdpServer.js
@@ -1,0 +1,192 @@
+var dgram = require('dgram');
+var net = require('net');
+
+var deviceProfile = require('./deviceProfile');
+var nvaSession = require('./nvaSession');
+
+function parseHeaders(raw) {
+  var lines = raw.split('\r\n');
+  var requestLine = lines.shift() || '';
+  var parts = requestLine.split(' ');
+  var headers = {};
+  lines.forEach(function (line) {
+    if (!line) return;
+    var idx = line.indexOf(':');
+    if (idx <= 0) return;
+    headers[line.slice(0, idx).trim().toLowerCase()] = line.slice(idx + 1).trim();
+  });
+  return {
+    method: parts[0] || '',
+    path: parts[1] || '/',
+    version: parts[2] || 'HTTP/1.1',
+    headers: headers,
+  };
+}
+
+function httpResponse(statusCode, statusText, headers, body) {
+  var lines = ['HTTP/1.1 ' + statusCode + ' ' + statusText];
+  Object.keys(headers || {}).forEach(function (key) {
+    lines.push(key + ': ' + headers[key]);
+  });
+  lines.push('', body || '');
+  return lines.join('\r\n');
+}
+
+function CastLanServer(options) {
+  options = options || {};
+  this.profile = options.profile;
+  this.controller = options.controller;
+  this.onFrame = options.onFrame;
+  this.tcpPort = this.profile.httpPort;
+  this.udpServer = null;
+  this.tcpServer = null;
+  this.broadcastTimer = null;
+  this.nextSessionId = 1;
+}
+
+CastLanServer.prototype.start = function (callback) {
+  var self = this;
+  self.startUdp();
+  self.startTcp(function () {
+    self.broadcastAlive();
+    self.broadcastTimer = setInterval(function () {
+      self.broadcastAlive();
+    }, 1000);
+    if (callback) callback();
+  });
+};
+
+CastLanServer.prototype.startUdp = function () {
+  var self = this;
+  self.udpServer = dgram.createSocket({ type: 'udp4', reuseAddr: true });
+  self.udpServer.on('message', function (msg, rinfo) {
+    var str = msg.toString('utf8');
+    if (str.toLowerCase().indexOf('ssdp:discover') < 0) return;
+    var st = 'urn:schemas-upnp-org:device:MediaRenderer:1';
+    var match = str.match(/\r\nST:\s*(.+)\r\n/i);
+    if (match) st = match[1].trim();
+    var response = deviceProfile.getSsdpSearchResponse(self.profile, st);
+    self.udpServer.send(Buffer.from(response), rinfo.port, rinfo.address);
+  });
+  self.udpServer.on('error', function (err) {
+    console.error('[Cast][SSDP] error:', err.message);
+  });
+  self.udpServer.bind(1900, function () {
+    try { self.udpServer.addMembership('239.255.255.250'); } catch (e) {}
+    try { self.udpServer.setBroadcast(true); } catch (e) {}
+    try { self.udpServer.setMulticastTTL(2); } catch (e) {}
+  });
+};
+
+CastLanServer.prototype.startTcp = function (callback) {
+  var self = this;
+  self.tcpServer = net.createServer(function (socket) {
+    self.handleSocket(socket);
+  });
+  self.tcpServer.on('error', function (err) {
+    console.error('[Cast][TCP] error:', err.message);
+    if (err.code === 'EADDRINUSE') {
+      self.tcpPort += 1;
+      self.profile.httpPort = self.tcpPort;
+      self.startTcp(callback);
+    }
+  });
+  self.tcpServer.listen(self.tcpPort, '0.0.0.0', callback);
+};
+
+CastLanServer.prototype.handleSocket = function (socket) {
+  var self = this;
+  var headerBuffer = '';
+  var handled = false;
+
+  function onData(chunk) {
+    if (handled) return;
+    headerBuffer += chunk.toString('utf8');
+    var idx = headerBuffer.indexOf('\r\n\r\n');
+    if (idx < 0) return;
+    handled = true;
+
+    var raw = headerBuffer.slice(0, idx);
+    var request = parseHeaders(raw);
+    socket.removeListener('data', onData);
+    self.routeRequest(socket, request);
+  }
+
+  socket.on('data', onData);
+};
+
+CastLanServer.prototype.routeRequest = function (socket, request) {
+  var path = request.path || '/';
+  if (request.method === 'SETUP' && path === '/projection') {
+    var session = new nvaSession.NvaSession(
+      'session-' + (this.nextSessionId++),
+      socket,
+      this.onFrame,
+      this.handleSessionClose.bind(this)
+    );
+    this.controller.attachSession(session);
+    session.startPing();
+    socket.write([
+      'NVA/1.0 200 OK',
+      'Session: ' + (request.headers.session || session.id),
+      'NvaVersion: 1',
+      'Connection: Keep-Alive',
+      'UUID: ' + this.profile.uuid,
+      'User-Agent: ' + this.profile.serverName.replace(',', ''),
+      '',
+      ''
+    ].join('\r\n'));
+    return;
+  }
+
+  var body = '';
+  var status = 200;
+  var statusText = 'OK';
+  var headers = { 'Content-Type': 'text/plain; charset=utf-8', 'Connection': 'close' };
+
+  if (request.method === 'GET' && path === '/description.xml') {
+    body = deviceProfile.renderDescriptionXml(this.profile);
+    headers['Content-Type'] = 'text/xml; charset=utf-8';
+  } else if (request.method === 'GET' && path === '/dlna/AVTransport.xml') {
+    body = deviceProfile.renderAvTransportScpd();
+    headers['Content-Type'] = 'text/xml; charset=utf-8';
+  } else if (request.method === 'GET' && path === '/dlna/NirvanaControl.xml') {
+    body = deviceProfile.renderNirvanaScpd();
+    headers['Content-Type'] = 'text/xml; charset=utf-8';
+  } else if (request.method === 'POST' && (path === '/AVTransport/action' || path === '/NirvanaControl/action')) {
+    body = '';
+  } else {
+    status = 404;
+    statusText = 'Not Found';
+    body = 'Not Found';
+  }
+
+  headers['Content-Length'] = Buffer.byteLength(body);
+  socket.end(httpResponse(status, statusText, headers, body));
+};
+
+CastLanServer.prototype.handleSessionClose = function (session) {
+  this.controller.detachSession(session.id);
+};
+
+CastLanServer.prototype.broadcastAlive = function () {
+  var self = this;
+  if (!self.udpServer) return;
+  deviceProfile.getSsdpNotifyPackets(self.profile).forEach(function (packet) {
+    self.udpServer.send(Buffer.from(packet), 1900, '239.255.255.250');
+  });
+};
+
+CastLanServer.prototype.stop = function () {
+  if (this.broadcastTimer) clearInterval(this.broadcastTimer);
+  if (this.udpServer) {
+    try { this.udpServer.close(); } catch (e) {}
+  }
+  if (this.tcpServer) {
+    try { this.tcpServer.close(); } catch (e) {}
+  }
+};
+
+module.exports = {
+  CastLanServer: CastLanServer,
+};

--- a/service/com.biliwebos.app.service/service.js
+++ b/service/com.biliwebos.app.service/service.js
@@ -9,7 +9,12 @@ var http = require('http');
 var zlib = require('zlib');
 var fs = require('fs');
 var path = require('path');
-var url = require('url');
+var os = require('os');
+var childProcess = require('child_process');
+
+var deviceProfile = require('./cast/deviceProfile');
+var CastController = require('./cast/castController').CastController;
+var CastLanServer = require('./cast/ssdpServer').CastLanServer;
 
 var service = new Service('com.biliwebos.app.service');
 
@@ -24,6 +29,22 @@ try {
 
 function saveCookies() {
   try { fs.writeFileSync(COOKIE_FILE, JSON.stringify(storedCookies)); } catch (e) { }
+}
+
+var CAST_CONFIG_FILE = path.join('/media/internal', 'bili_cast_config.json');
+var castConfig = {};
+try {
+  if (fs.existsSync(CAST_CONFIG_FILE)) {
+    castConfig = JSON.parse(fs.readFileSync(CAST_CONFIG_FILE, 'utf-8'));
+  }
+} catch (e) { }
+
+if (castConfig.friendlyName === 'B站 webOS') {
+  castConfig.friendlyName = '我的小电视';
+}
+
+function saveCastConfig() {
+  try { fs.writeFileSync(CAST_CONFIG_FILE, JSON.stringify(castConfig)); } catch (e) { }
 }
 
 function serializeCookies(cookies) {
@@ -109,6 +130,95 @@ function decompressResponse(res, callback) {
   });
 }
 
+function getLanIp() {
+  var nets = os.networkInterfaces();
+  var names = Object.keys(nets);
+  for (var i = 0; i < names.length; i++) {
+    var rows = nets[names[i]] || [];
+    for (var j = 0; j < rows.length; j++) {
+      var row = rows[j];
+      if (row && row.family === 'IPv4' && !row.internal) return row.address;
+    }
+  }
+  return '127.0.0.1';
+}
+
+function getCastFriendlyName() {
+  return castConfig.friendlyName || '我的小电视';
+}
+
+var castController = new CastController();
+var castSubscribers = [];
+var pendingCastEvent = null;
+var castProfile = deviceProfile.createDeviceProfile({
+  uuid: castConfig.uuid,
+  friendlyName: getCastFriendlyName(),
+  ip: getLanIp(),
+  httpPort: 9958,
+});
+
+castConfig.uuid = castProfile.uuid;
+saveCastConfig();
+
+function notifyCastSubscribers(event) {
+  pendingCastEvent = event;
+  castSubscribers = castSubscribers.filter(function (message) {
+    try {
+      message.respond({
+        returnValue: true,
+        subscribed: true,
+        event: event,
+        status: castController.getStatus(),
+      });
+      pendingCastEvent = null;
+      return true;
+    } catch (e) {
+      return false;
+    }
+  });
+}
+
+function launchAppForCast() {
+  childProcess.execFile('luna-send-pub', [
+    '-n', '1', '-f',
+    'luna://com.webos.service.applicationmanager/launch',
+    '{"id":"com.biliwebos.app"}'
+  ], function (err, stdout, stderr) {
+    if (err) {
+      console.error('[Cast] launch app failed:', err.message);
+      return;
+    }
+    if (stderr) console.log('[Cast] launch stderr:', stderr.trim());
+    if (stdout) console.log('[Cast] launch:', stdout.trim());
+  });
+}
+
+castController.onIntent(function (intent) {
+  launchAppForCast();
+  notifyCastSubscribers({ kind: 'command', command: intent });
+});
+
+var castLanServer = new CastLanServer({
+  profile: castProfile,
+  controller: castController,
+  onFrame: function (session, frame) {
+    if (frame.action === 'GetVolume') {
+      session.sendReply({ volume: 30 });
+      return;
+    }
+    if (frame.type !== 'command') return;
+
+    var intent = castController.handleCommand(session.id, frame.action, frame.body);
+    if (frame.action === 'PlayUrl' && !intent) {
+      session.sendReply({ accepted: false, reason: 'unsupported-playurl' });
+      return;
+    }
+    session.sendEmpty();
+  },
+});
+
+castController.setNetworkInfo(castProfile.ip, castProfile.httpPort);
+
 // ==================== Luna Bus Methods ====================
 
 service.register('fetch', function (message) {
@@ -167,8 +277,57 @@ service.register('ping', function (message) {
     returnValue: true, status: 'ok',
     cookieKeys: Object.keys(storedCookies),
     nodeVersion: process.version,
-    localProxyPort: LOCAL_PROXY_PORT
+    localProxyPort: LOCAL_PROXY_PORT,
+    castHttpPort: castProfile.httpPort,
+    castFriendlyName: getCastFriendlyName(),
   });
+});
+
+service.register('castSubscribe', function (message) {
+  if (message.isSubscription || message.payload.subscribe) {
+    castSubscribers.push(message);
+    message.respond({
+      returnValue: true,
+      subscribed: true,
+      event: pendingCastEvent || { kind: 'ready' },
+      status: castController.getStatus(),
+    });
+    if (pendingCastEvent && pendingCastEvent.kind === 'command') pendingCastEvent = null;
+    return;
+  }
+  message.respond({
+    returnValue: true,
+    subscribed: false,
+    status: castController.getStatus(),
+  });
+});
+
+service.register('castAck', function (message) {
+  castController.ack(message.payload || {});
+  message.respond({ returnValue: true, status: castController.getStatus() });
+});
+
+service.register('castReportState', function (message) {
+  castController.reportState(message.payload || {});
+  notifyCastSubscribers({ kind: 'state', payload: message.payload || {} });
+  message.respond({ returnValue: true });
+});
+
+service.register('castReportProgress', function (message) {
+  castController.reportProgress(message.payload || {});
+  message.respond({ returnValue: true });
+});
+
+service.register('castGetStatus', function (message) {
+  message.respond({ returnValue: true, status: castController.getStatus() });
+});
+
+service.register('castSetConfig', function (message) {
+  if (message.payload && message.payload.friendlyName) {
+    castConfig.friendlyName = String(message.payload.friendlyName).slice(0, 64);
+    saveCastConfig();
+  }
+  message.respond({ returnValue: true, config: castConfig });
 });
 
 // ==================== Local HTTP Proxy ====================
@@ -239,6 +398,12 @@ localServer.on('error', function (err) {
 
 localServer.listen(LOCAL_PROXY_PORT, '127.0.0.1', function () {
   console.log('[BiliService] Local proxy on port ' + LOCAL_PROXY_PORT);
+});
+
+castLanServer.start(function () {
+  castProfile.ip = getLanIp();
+  castController.setNetworkInfo(castProfile.ip, castProfile.httpPort);
+  console.log('[BiliService] Cast server on ' + castProfile.ip + ':' + castProfile.httpPort);
 });
 
 // Keep service alive

--- a/service/com.biliwebos.app.service/test/cast-controller.test.js
+++ b/service/com.biliwebos.app.service/test/cast-controller.test.js
@@ -1,0 +1,94 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { CastController } = require('../cast/castController');
+
+test('parse play command into video intent', () => {
+  const controller = new CastController();
+
+  const intent = controller.handleCommand('session-1', 'Play', JSON.stringify({
+    aid: 123,
+    bvid: 'BV1xx411c7mD',
+    cid: 456,
+    title: 'test video',
+  }));
+
+  assert.equal(intent.type, 'play');
+  assert.equal(intent.contentType, 'video');
+  assert.equal(intent.aid, 123);
+  assert.equal(intent.bvid, 'BV1xx411c7mD');
+  assert.equal(intent.cid, 456);
+  assert.equal(intent.title, 'test video');
+});
+
+test('parse play command into live intent', () => {
+  const controller = new CastController();
+
+  const intent = controller.handleCommand('session-1', 'Play', JSON.stringify({
+    roomId: 987654,
+    title: 'live room',
+  }));
+
+  assert.equal(intent.type, 'play');
+  assert.equal(intent.contentType, 'live');
+  assert.equal(intent.roomId, 987654);
+});
+
+test('parse playurl command via nva_ext payload into video intent', () => {
+  const controller = new CastController();
+  const ext = encodeURIComponent(JSON.stringify({
+    content: {
+      aid: 22,
+      cid: 33,
+      bvid: 'BV1ab411c7mD',
+      title: 'from playurl',
+    },
+  }));
+
+  const intent = controller.handleCommand('session-1', 'PlayUrl', JSON.stringify({
+    url: `https://example.com/play?foo=bar&nva_ext=${ext}`,
+  }));
+
+  assert.equal(intent.type, 'play');
+  assert.equal(intent.contentType, 'video');
+  assert.equal(intent.aid, 22);
+  assert.equal(intent.cid, 33);
+  assert.equal(intent.bvid, 'BV1ab411c7mD');
+});
+
+test('unsupported playurl payload is ignored without clobbering active session', () => {
+  const controller = new CastController();
+
+  controller.handleCommand('session-1', 'Play', JSON.stringify({ aid: 1, cid: 2, bvid: 'BV1' }));
+  const before = controller.getStatus();
+  const result = controller.handleCommand('session-1', 'PlayUrl', JSON.stringify({
+    url: 'https://example.com/play?foo=bar',
+  }));
+  const after = controller.getStatus();
+
+  assert.equal(result, null);
+  assert.deepEqual(after.activeContent, before.activeContent);
+});
+
+test('reporting state and progress produces outbound NVA events', () => {
+  const controller = new CastController();
+  const sent = [];
+
+  controller.attachSession({
+    id: 'session-1',
+    sendCommand(action, content) {
+      sent.push({ action, content });
+    },
+    sendReply() {},
+    sendEmpty() {},
+  });
+
+  controller.handleCommand('session-1', 'Play', JSON.stringify({ aid: 1, cid: 2, bvid: 'BV1' }));
+  controller.reportState({ playState: 'playing' });
+  controller.reportProgress({ duration: 100, position: 45 });
+
+  assert.deepEqual(sent, [
+    { action: 'OnPlayState', content: { playState: 4 } },
+    { action: 'OnProgress', content: { duration: 100, position: 45 } },
+  ]);
+});

--- a/service/com.biliwebos.app.service/test/cast-controller.test.js
+++ b/service/com.biliwebos.app.service/test/cast-controller.test.js
@@ -11,6 +11,7 @@ test('parse play command into video intent', () => {
     bvid: 'BV1xx411c7mD',
     cid: 456,
     title: 'test video',
+    seekTs: 123.4,
   }));
 
   assert.equal(intent.type, 'play');
@@ -19,6 +20,7 @@ test('parse play command into video intent', () => {
   assert.equal(intent.bvid, 'BV1xx411c7mD');
   assert.equal(intent.cid, 456);
   assert.equal(intent.title, 'test video');
+  assert.equal(intent.seekTs, 123.4);
 });
 
 test('parse play command into live intent', () => {
@@ -91,4 +93,11 @@ test('reporting state and progress produces outbound NVA events', () => {
     { action: 'OnPlayState', content: { playState: 4 } },
     { action: 'OnProgress', content: { duration: 100, position: 45 } },
   ]);
+});
+
+
+test('parse seek command with seekTs field', () => {
+  const controller = new CastController();
+  const intent = controller.handleCommand('session-1', 'Seek', JSON.stringify({ seekTs: 88 }));
+  assert.deepEqual(intent, { type: 'seek', positionSec: 88 });
 });

--- a/service/com.biliwebos.app.service/test/device-profile.test.js
+++ b/service/com.biliwebos.app.service/test/device-profile.test.js
@@ -1,0 +1,50 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createDeviceProfile,
+  renderDescriptionXml,
+  getSsdpNotifyPackets,
+  getSsdpSearchResponse,
+} = require('../cast/deviceProfile');
+
+test('description xml exposes AVTransport and NirvanaControl services', () => {
+  const profile = createDeviceProfile({ ip: '192.168.1.2', httpPort: 9958, friendlyName: 'B站 webOS' });
+  const xml = renderDescriptionXml(profile);
+
+  assert.match(xml, /<friendlyName>B站 webOS<\/friendlyName>/);
+  assert.match(xml, /urn:schemas-upnp-org:service:AVTransport:1/);
+  assert.match(xml, /urn:app-bilibili-com:service:NirvanaControl:3/);
+  assert.match(xml, /<controlURL>AVTransport\/action<\/controlURL>/);
+  assert.match(xml, /<controlURL>NirvanaControl\/action<\/controlURL>/);
+});
+
+test('default device profile matches official-style bilibili renderer fields', () => {
+  const profile = createDeviceProfile({ ip: '192.168.1.2', httpPort: 9958 });
+  const xml = renderDescriptionXml(profile);
+
+  assert.match(xml, /<friendlyName>我的小电视<\/friendlyName>/);
+  assert.match(xml, /<X_brandName>ATV<\/X_brandName>/);
+  assert.match(xml, /<modelDescription>云视听小电视<\/modelDescription>/);
+});
+
+test('ssdp packets advertise media renderer and nirvana service', () => {
+  const profile = createDeviceProfile({ ip: '192.168.1.2', httpPort: 9958 });
+
+  const packets = getSsdpNotifyPackets(profile);
+  const joined = packets.join('\n---\n');
+
+  assert.match(joined, /NTS: ssdp:alive/);
+  assert.match(joined, /urn:schemas-upnp-org:device:MediaRenderer:1/);
+  assert.match(joined, /urn:app-bilibili-com:service:NirvanaControl:3/);
+});
+
+test('ssdp search response points to description xml', () => {
+  const profile = createDeviceProfile({ ip: '192.168.1.2', httpPort: 9958 });
+  const response = getSsdpSearchResponse(profile, 'urn:schemas-upnp-org:device:MediaRenderer:1');
+
+  assert.match(response, /HTTP\/1\.1 200 OK/);
+  assert.match(response, /LOCATION: http:\/\/192\.168\.1\.2:9958\/description\.xml/);
+  assert.match(response, /USN: uuid:atvbilibili&/);
+  assert.match(response, /ST: upnp:rootdevice/);
+});

--- a/service/com.biliwebos.app.service/test/nva-session.test.js
+++ b/service/com.biliwebos.app.service/test/nva-session.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  decodeFrame,
+  encodeEmptyReply,
+  encodeJsonReply,
+  encodeCommand,
+} = require('../cast/nvaSession');
+
+test('decode command frame with json body', () => {
+  const frame = Buffer.concat([
+    Buffer.from([0xe0, 0x03, 0x00, 0x00, 0x00, 0x02, 0x01, 0x07]),
+    Buffer.from('Command'),
+    Buffer.from([0x04]),
+    Buffer.from('Play'),
+    Buffer.from([0x00, 0x00, 0x00, 0x14]),
+    Buffer.from('{"aid":1,"cid":2}'),
+  ]);
+
+  const decoded = decodeFrame(frame);
+
+  assert.equal(decoded.type, 'command');
+  assert.equal(decoded.action, 'Play');
+  assert.equal(decoded.body, '{"aid":1,"cid":2}');
+  assert.equal(decoded.version, 2);
+});
+
+test('encode json reply and command frames', () => {
+  const reply = encodeJsonReply(3, { volume: 30 });
+  const command = encodeCommand(4, 'OnPlayState', { playState: 4 });
+
+  assert.equal(reply[0], 0xc0);
+  assert.equal(reply[1], 0x01);
+  assert.equal(command[0], 0xe0);
+  assert.equal(command[1], 0x03);
+});
+
+test('encode empty reply frame', () => {
+  const reply = encodeEmptyReply(7);
+
+  assert.deepEqual(Array.from(reply.subarray(0, 6)), [0xc0, 0x00, 0x00, 0x00, 0x00, 0x07]);
+});


### PR DESCRIPTION
Description
本 PR 为 webOS TV 增加 B 站原生投屏接收能力，不依赖 AirPlay / Chromecast。TV 端会在局域网中以 MediaRenderer + NirvanaControl:3 形式被手机 B 站 App 识别，并接收投屏命令后接管本机播放器完成播放。

What’s included

新增投屏接收服务，支持局域网 SSDP 发现与 description.xml 暴露
新增 SETUP /projection NVA 会话链路，支持命令帧解析与回包
新增投屏控制器，将 Play / PlayUrl / Pause / Resume / Seek / Stop / SwitchDanmaku 转换为前端可消费的播放意图
前端常驻订阅投屏事件，收到命令后自动切换到对应视频或直播页
播放器支持外部接管，并回传 playState / progress
设备画像、UUID、SSDP 响应字段做了官方风格兼容
Behavior

手机端点击投屏后，TV 端会主动接管播放
点播与直播均可通过投屏进入
支持基础控制命令与状态回传
电视端使用本机登录态和现有播放能力完成实际播放
Verification

npm test
npm --prefix app run build
bash build.sh
真机 TV 上完成局域网发现、SETUP、Play 命令链路验证
Notes

本 PR 只覆盖“投屏接收端”能力，不包含其他播放链路的重构
投屏协议实现以当前可观察到的 B 站官方接收端行为为参考，后续可根据真机抓包继续微调兼容性