### PR TITLE
Fix playback freeze/slow-load + UP-videos tab, follow badge & pagination

### DIFF
--- a/app/src/api/client.js
+++ b/app/src/api/client.js
@@ -165,9 +165,17 @@ export async function getRegionDynamic(rid, pn, ps) {
   return wbiFetch('/x/web-interface/dynamic/region', { rid: rid || 0, pn: pn || 1, ps: ps || 6 });
 }
 
-// Follow feed
-export async function getFollowFeed(page, ps) {
-  return smartFetch(API_HOST, '/x/polymer/web-dynamic/v1/feed/all?timezone_offset=-480&type=video&page=' + (page || 1));
+// Follow feed — paginates by the `offset` cursor returned in data.offset,
+// NOT by page number (page alone re-returns the first page).
+export async function getFollowFeed(page, offset) {
+  var url = '/x/polymer/web-dynamic/v1/feed/all?timezone_offset=-480&type=video&page=' + (page || 1);
+  if (offset) url += '&offset=' + encodeURIComponent(offset);
+  return smartFetch(API_HOST, url);
+}
+
+// Logged-in user's followings (Cookie auth). Used to badge "已关注" on cards.
+export async function getFollowings(vmid, pn, ps) {
+  return apiFetch('/x/relation/followings', { vmid: vmid, pn: pn || 1, ps: ps || 50, order: 'desc' });
 }
 
 // ============ Live ============
@@ -294,4 +302,14 @@ function parseDanmakuXml(xml) {
 
 export async function getRelated(bvid) {
   return wbiFetch('/x/web-interface/archive/related', { bvid: bvid });
+}
+
+// ============ UP uploader ============
+
+// This uploader's submitted videos, newest first (space arc search, WBI signed)
+export async function getUpVideos(mid, pn, ps) {
+  return wbiFetch('/x/space/wbi/arc/search', {
+    mid: mid, pn: pn || 1, ps: ps || 30, order: 'pubdate', tid: 0, keyword: '',
+    platform: 'web', web_location: 1550101,
+  });
 }

--- a/app/src/components/VideoCard.jsx
+++ b/app/src/components/VideoCard.jsx
@@ -23,7 +23,7 @@ function proxyImg(url) {
   }
 }
 
-export default React.memo(function VideoCard({ video, focusId, row, col, group, onSelect }) {
+export default React.memo(function VideoCard({ video, focusId, row, col, group, onSelect, followed = false }) {
   const handleSelect = useCallback(() => {
     onSelect?.(video);
   }, [video, onSelect]);
@@ -59,6 +59,7 @@ export default React.memo(function VideoCard({ video, focusId, row, col, group, 
         <div className="video-card-title">{video.title}</div>
         <div className="video-card-meta">
           {video.owner?.name && <span>{video.owner.name}</span>}
+          {followed && <span style={{ color: '#00a1d6', fontWeight: 600 }}>已关注</span>}
           {video.stat?.view != null && <span>{formatCount(video.stat.view)}播放</span>}
           {video.play != null && <span>{formatCount(video.play)}播放</span>}
           {video.pubdate && <span>{formatTime(video.pubdate)}</span>}

--- a/app/src/components/VideoGrid.jsx
+++ b/app/src/components/VideoGrid.jsx
@@ -3,7 +3,7 @@ import VideoCard from './VideoCard';
 
 // Use transform:translateY for scrolling instead of overflow:scroll
 // This pushes scroll to GPU compositor, avoiding layout recalculation
-export default React.memo(function VideoGrid({ videos, group = 'content', startRow = 0, cols = 2, onSelect, focusRow = 0 }) {
+export default React.memo(function VideoGrid({ videos, group = 'content', startRow = 0, cols = 2, onSelect, focusRow = 0, followedMids = null }) {
   if (!videos || videos.length === 0) {
     return <div className="empty-state">暂无内容</div>;
   }
@@ -41,6 +41,7 @@ export default React.memo(function VideoGrid({ videos, group = 'content', startR
               col={col}
               group={group}
               onSelect={onSelect}
+              followed={!!(followedMids && video.owner?.mid && followedMids.has(video.owner.mid))}
             />
           );
         })}

--- a/app/src/components/VideoRow.jsx
+++ b/app/src/components/VideoRow.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import VideoCard from './VideoCard';
+
+export default React.memo(function VideoRow({ title, videos, rowIndex, group, onSelect }) {
+  return (
+    <div style={{ marginTop: 8 }}>
+      {title && <div className="section-title">{title}</div>}
+      <div style={{ display: 'flex', gap: 20, padding: '10px 36px', overflow: 'hidden' }}>
+        {videos.map((video, idx) => {
+          const bvid = video.bvid || video.bv_id;
+          return (
+            <VideoCard
+              key={bvid || `v-${rowIndex}-${idx}`}
+              video={video}
+              focusId={`${group}-${rowIndex}-${idx}`}
+              row={rowIndex}
+              col={idx}
+              group={group}
+              onSelect={onSelect}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+});

--- a/app/src/pages/HomePage.jsx
+++ b/app/src/pages/HomePage.jsx
@@ -2,18 +2,22 @@ import React, { useState, useEffect, useRef } from 'react';
 import { getPopular, getRecommend, getRegionDynamic, getFollowFeed, getLiveList } from '../api/client';
 import VideoGrid from '../components/VideoGrid';
 import { getCurrentFocusId, setFocus, onFocusChange } from '../hooks/useFocus';
+import { storage } from '../utils/storage';
+import { loadFollowedMids } from '../utils/follow';
 
 const COLS = 2;
 const FETCH_SIZE = 20;
 
-async function fetchByMode(mode, pn) {
+// Returns { items, offset } — offset is the follow-feed cursor (undefined for
+// other modes, which paginate by page number).
+async function fetchByMode(mode, pn, offset) {
   if (mode === 'hot') {
     const res = await getPopular(pn, FETCH_SIZE);
-    return res?.data?.list || [];
+    return { items: res?.data?.list || [] };
   } else if (mode === 'live') {
     const res = await getLiveList(pn, FETCH_SIZE);
     const items = res?.data?.list || res?.data?.recommend_room_list || [];
-    return items.map(item => ({
+    return { items: items.map(item => ({
       bvid: `live-${item.roomid}`,
       title: item.title,
       pic: item.cover || item.system_cover,
@@ -21,27 +25,29 @@ async function fetchByMode(mode, pn) {
       stat: { view: item.online || item.watched_show?.num },
       isLive: true,
       roomid: item.roomid,
-    }));
+    })) };
   } else if (mode === 'partition') {
     const rids = [1, 3, 4, 5, 17, 36, 160, 188, 211];
     const rid = rids[Math.floor(Math.random() * rids.length)];
     const res = await getRegionDynamic(rid, pn, FETCH_SIZE);
-    return res?.data?.archives || [];
+    return { items: res?.data?.archives || [] };
   } else if (mode === 'follow') {
-    const res = await getFollowFeed(pn, FETCH_SIZE);
-    return (res?.data?.items || []).map(item => {
+    const res = await getFollowFeed(pn, offset);
+    const items = (res?.data?.items || []).map(item => {
       const archive = item.modules?.module_dynamic?.major?.archive;
       if (!archive) return null;
       return {
         bvid: archive.bvid, title: archive.title, pic: archive.cover,
         duration: archive.duration_text, pubdate: archive.pubdate,
-        owner: { name: item.modules?.module_author?.name },
+        owner: { name: item.modules?.module_author?.name, mid: item.modules?.module_author?.mid },
         stat: { view: archive.stat?.play },
       };
     }).filter(Boolean);
+    items.sort((a, b) => (b.pubdate || 0) - (a.pubdate || 0)); // newest first
+    return { items, offset: res?.data?.offset };
   } else {
     const res = await getRecommend(4, FETCH_SIZE);
-    return res?.data?.item || [];
+    return { items: res?.data?.item || [] };
   }
 }
 
@@ -49,7 +55,9 @@ export default function HomePage({ onPlayVideo, refreshKey, mode = 'recommend' }
   const [videos, setVideos] = useState([]);
   const [loading, setLoading] = useState(true);
   const [focusRow, setFocusRow] = useState(0);
+  const [followedMids, setFollowedMids] = useState(null);
   const pageRef = useRef(1);
+  const offsetRef = useRef('');
   const seenRef = useRef(new Set());
   const fetchingRef = useRef(false);
 
@@ -58,15 +66,17 @@ export default function HomePage({ onPlayVideo, refreshKey, mode = 'recommend' }
     let cancelled = false;
     seenRef.current = new Set();
     pageRef.current = 1;
+    offsetRef.current = '';
     setLoading(true);
     setVideos([]);
     setFocusRow(0);
 
-    fetchByMode(mode, 1).then(items => {
+    fetchByMode(mode, 1, '').then(({ items, offset }) => {
       if (cancelled) return;
       setVideos(dedupe(items));
       setLoading(false);
       pageRef.current = 2;
+      offsetRef.current = offset || '';
       // Only focus content if not currently in sidebar
       setTimeout(() => {
         const cur = getCurrentFocusId();
@@ -78,6 +88,13 @@ export default function HomePage({ onPlayVideo, refreshKey, mode = 'recommend' }
 
     return () => { cancelled = true; };
   }, [refreshKey, mode]);
+
+  // Load followed UP mids once (logged-in only) to badge "已关注" on cards
+  useEffect(() => {
+    if (storage.getAuth()?.SESSDATA) {
+      loadFollowedMids().then(set => { if (set && set.size) setFollowedMids(set); });
+    }
+  }, []);
 
   function dedupe(items) {
     return items.filter(v => {
@@ -101,10 +118,11 @@ export default function HomePage({ onPlayVideo, refreshKey, mode = 'recommend' }
       const totalRows = Math.ceil(videos.length / COLS);
       if (row >= totalRows - 2 && !fetchingRef.current) {
         fetchingRef.current = true;
-        fetchByMode(mode, pageRef.current).then(items => {
+        fetchByMode(mode, pageRef.current, offsetRef.current).then(({ items, offset }) => {
           const unique = dedupe(items);
           if (unique.length > 0) setVideos(prev => [...prev, ...unique]);
           pageRef.current++;
+          if (offset) offsetRef.current = offset;
           fetchingRef.current = false;
         }).catch(() => { fetchingRef.current = false; });
       }
@@ -123,6 +141,7 @@ export default function HomePage({ onPlayVideo, refreshKey, mode = 'recommend' }
       cols={COLS}
       onSelect={onPlayVideo}
       focusRow={focusRow}
+      followedMids={followedMids}
     />
   );
 }

--- a/app/src/player/PlayerPage.jsx
+++ b/app/src/player/PlayerPage.jsx
@@ -1,9 +1,25 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { getPlayUrl, getDanmaku, getVideoInfo, reportHeartbeat, getRelated } from '../api/client';
-import { formatDuration, QUALITY_MAP } from '../utils/format';
+import { getPlayUrl, getDanmaku, getVideoInfo, reportHeartbeat, getRelated, getUpVideos } from '../api/client';
+import { formatDuration, formatTime, QUALITY_MAP } from '../utils/format';
 import { storage } from '../utils/storage';
 import { setCustomKeyHandler } from '../hooks/useFocus';
 import DanmakuLayer from './DanmakuLayer';
+
+// Proxy + resize card thumbnails (same as VideoCard): the proxy adds the
+// Referer B站 image CDN needs, and @672w webp keeps the TV's image decoder from
+// choking on full-size covers (which is why direct-loaded thumbs failed).
+function proxyImg(url) {
+  if (!url) return '';
+  let u = url.startsWith('//') ? 'https:' + url : url;
+  if (u.includes('hdslb.com') && !u.includes('@')) u += '@672w_420h_1c.webp';
+  const base = (typeof window !== 'undefined' && window.webOS) ? 'http://127.0.0.1:7654' : storage.getProxyUrl();
+  try {
+    const parsed = new URL(u);
+    return `${base}/proxy/${parsed.host}${parsed.pathname}${parsed.search}`;
+  } catch {
+    return u;
+  }
+}
 
 export default function PlayerPage({ video, onBack, onPlayNext }) {
   const videoRef = useRef(null);
@@ -20,17 +36,27 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
   const [danmakuEnabled, setDanmakuEnabled] = useState(true);
   const [videoTitle, setVideoTitle] = useState(video?.title || '');
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
   const [ended, setEnded] = useState(false);
   const [relatedVideos, setRelatedVideos] = useState([]);
-  // Focus: 'none' (no UI) | 'controls' | 'quality' | 'related' | 'endscreen'
+  // Bottom panel: 'related' (相关推荐) | 'up' (UP主投稿)
+  const [panelTab, setPanelTab] = useState('related');
+  const [upVideos, setUpVideos] = useState([]);
+  const [upName, setUpName] = useState('');
+  // Focus: 'none' | 'controls' | 'quality' | 'tabs' | 'related' (=grid) | 'endscreen'
   const [focusArea, setFocusArea] = useState('none');
   const [focusIdx, setFocusIdx] = useState(0);
   const controlsTimer = useRef(null);
   const timeUpdateRef = useRef(null);
   const cidRef = useRef(null);
   const startTimeRef = useRef(Date.now());
+  const upMidRef = useRef(null);
+  const upLoadingRef = useRef(false);
+  const upPnRef = useRef(1);
+  const upSeenRef = useRef(new Set());
 
   const CONTROLS = ['play', 'danmaku', 'quality'];
+  const END_SCREEN_MAX = 8; // up to 2 rows of 4 on the end screen
 
   // Initialize Shaka Player
   useEffect(() => {
@@ -42,7 +68,47 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
       const player = new shaka.Player();
       await player.attach(videoRef.current);
       shakaRef.current = player;
-      player.addEventListener('error', (e) => console.error('Shaka error:', e.detail));
+
+      // Resilience: more retries + longer timeouts so a flaky segment fetch is
+      // retried instead of fataling the whole playback (TV CDN is unreliable).
+      player.configure({
+        // ABR off: the app has an explicit quality selector, so don't let
+        // Shaka silently downgrade bitrate mid-playback on bandwidth wobble.
+        abr: { enabled: false },
+        // No exponential backoff: keep retries for reliability but a flat,
+        // short delay so a transient failure doesn't add seconds of dead wait
+        // (an aggressive backoff here added ~7.5s to every load).
+        manifest: { retryParameters: { maxAttempts: 4, baseDelay: 150, backoffFactor: 1, timeout: 15000 } },
+        streaming: {
+          retryParameters: { maxAttempts: 6, baseDelay: 200, backoffFactor: 1, fuzzFactor: 0.5, timeout: 20000 },
+          bufferingGoal: 30,
+          rebufferingGoal: 2,
+        },
+      });
+
+      // On a network/media error, resume streaming instead of dying silently.
+      // category 1 = NETWORK, 3 = MEDIA — usually recoverable mid-playback.
+      player.addEventListener('error', (e) => {
+        const err = e.detail;
+        console.error('Shaka error code:', err?.code, 'category:', err?.category, err);
+        if (err && (err.category === 1 || err.category === 3)) {
+          try { player.retryStreaming(); } catch {}
+        }
+      });
+
+      // Rewrite all media/segment URLs through the local proxy (TV) or Mac
+      // proxy. Registered once here — not per load — so retries don't stack
+      // duplicate filters.
+      player.getNetworkingEngine().registerRequestFilter((type, request) => {
+        if (request.uris[0] && request.uris[0].startsWith('http')) {
+          const originalUrl = new URL(request.uris[0]);
+          const proxyBase = (typeof window !== 'undefined' && window.webOS)
+            ? 'http://127.0.0.1:7654'
+            : storage.getProxyUrl();
+          request.uris[0] = `${proxyBase}/proxy/${originalUrl.host}${originalUrl.pathname}${originalUrl.search}`;
+        }
+      });
+
       if (mounted) loadVideo(player);
     }
     init();
@@ -52,46 +118,68 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
   const loadVideo = useCallback(async (player) => {
     if (!video?.bvid) return;
     setLoading(true);
+    setLoadError(false);
     try {
       let cid = video.cid;
+      let ownerMid = video.owner?.mid || null;
+      let ownerName = video.owner?.name || '';
       if (!cid) {
         const info = await getVideoInfo(video.bvid);
         cid = info?.data?.cid;
         if (info?.data?.title) setVideoTitle(info.data.title);
+        if (info?.data?.owner) {
+          ownerMid = ownerMid || info.data.owner.mid;
+          ownerName = ownerName || info.data.owner.name;
+        }
       }
-      if (!cid) return;
+      if (!cid) throw new Error('No cid for video');
       cidRef.current = cid;
+      // Reset the "UP主投稿" tab for this uploader
+      upMidRef.current = ownerMid;
+      upPnRef.current = 1;
+      upSeenRef.current = new Set();
+      setUpVideos([]);
+      setUpName(ownerName || '');
+      setPanelTab('related');
 
       const settings = storage.getSettings();
-      const res = await getPlayUrl(video.bvid, cid, settings.quality || 80);
-      const dash = res?.data?.dash;
-      if (!dash) return;
+      let loaded = false;
+      let lastErr = null;
+      // Re-fetch playurl + retry: a fresh playurl hands back different CDN
+      // nodes, and buildMPD now carries backup URLs, so a bad node fails over
+      // instead of leaving a black "loading forever" screen.
+      for (let attempt = 0; attempt < 3 && !loaded; attempt++) {
+        try {
+          const res = await getPlayUrl(video.bvid, cid, settings.quality || 80);
+          const dash = res?.data?.dash;
+          if (!dash) throw new Error('No DASH stream in playurl (DRM/bangumi?)');
 
-      setQualities((res?.data?.accept_quality || []).map(q => ({ qn: q, label: QUALITY_MAP[q] || `${q}` })));
-      setCurrentQuality(res?.data?.quality || 80);
+          setQualities((res?.data?.accept_quality || []).map(q => ({ qn: q, label: QUALITY_MAP[q] || `${q}` })));
+          setCurrentQuality(res?.data?.quality || 80);
 
-      const mpd = buildMPD(dash);
-      const blob = new Blob([mpd], { type: 'application/dash+xml' });
-      const mpdUrl = URL.createObjectURL(blob);
-
-      player.getNetworkingEngine().registerRequestFilter((type, request) => {
-        if (request.uris[0].startsWith('http')) {
-          const originalUrl = new URL(request.uris[0]);
-          // Use local proxy on TV (JS Service), fallback to Mac proxy
-          const proxyBase = (typeof window !== 'undefined' && window.webOS)
-            ? 'http://127.0.0.1:7654'
-            : storage.getProxyUrl();
-          request.uris[0] = `${proxyBase}/proxy/${originalUrl.host}${originalUrl.pathname}${originalUrl.search}`;
+          const mpd = buildMPD(dash);
+          const blob = new Blob([mpd], { type: 'application/dash+xml' });
+          const mpdUrl = URL.createObjectURL(blob);
+          // Resume directly at the saved position via load()'s startTime — don't
+          // load at 0 then seek, which buffers the intro and immediately throws
+          // it away (the main cause of the long resume-load wait).
+          const resumeAt = (video.progress && video.progress > 0 && video.progress < (dash.duration || 9999) - 10)
+            ? video.progress : 0;
+          try {
+            await player.load(mpdUrl, resumeAt || undefined);
+          } finally {
+            URL.revokeObjectURL(mpdUrl);
+          }
+          loaded = true;
+        } catch (e) {
+          lastErr = e;
+          console.warn('[loadVideo] attempt ' + (attempt + 1) + ' failed:', e?.message || e);
+          if (attempt < 2) await new Promise(r => setTimeout(r, 800));
         }
-      });
-
-      await player.load(mpdUrl);
-      URL.revokeObjectURL(mpdUrl);
-
-      if (video.progress && video.progress > 0 && video.progress < (dash.duration || 9999) - 10) {
-        videoRef.current.currentTime = video.progress;
       }
+      if (!loaded) throw lastErr || new Error('Playback load failed');
 
+      selectBestVariant(player);
       videoRef.current.play();
       setPlaying(true);
       setLoading(false);
@@ -109,20 +197,28 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
         setRelatedVideos((rel?.data || []).slice(0, 12));
       } catch {}
     } catch (err) {
-      console.error('Load video error:', err);
+      console.error('Load video error:', err?.message || err);
       setLoading(false);
+      setLoadError(true);
     }
   }, [video]);
 
   function buildMPD(dash) {
     const duration = dash.duration || 0;
     const minBuffer = dash.minBufferTime || 1.5;
+    // ABR is off and manual quality re-fetches playurl, so the MPD only needs
+    // the single highest-bitrate video + audio. Emitting every quality/codec
+    // (B站 returns AVC+HEVC+AV1 × resolutions) makes Shaka's parse/codec-probe
+    // on the TV's weak CPU take several seconds before the first byte loads.
+    const pickBest = (arr) => (arr && arr.length)
+      ? [arr.reduce((a, b) => ((b.bandwidth || 0) > (a.bandwidth || 0) ? b : a))] : [];
+    const videoList = pickBest(dash.video);
+    const audioList = pickBest(dash.audio);
     let videoAdaptations = '';
-    if (dash.video?.length > 0) {
-      const reps = dash.video.map(v => {
-        const baseUrl = v.baseUrl || v.base_url || '';
+    if (videoList.length > 0) {
+      const reps = videoList.map(v => {
         return `<Representation id="${v.id}" bandwidth="${v.bandwidth || 1000000}" codecs="${v.codecs || 'avc1.640032'}" mimeType="${v.mimeType || 'video/mp4'}" width="${v.width || 1920}" height="${v.height || 1080}" frameRate="${v.frameRate || v.frame_rate || '30'}">
-          <BaseURL>${escapeXml(baseUrl)}</BaseURL>
+          ${buildBaseUrls(v)}
           <SegmentBase indexRange="${v.SegmentBase?.indexRange || v.segment_base?.index_range || '0-0'}">
             <Initialization range="${v.SegmentBase?.Initialization || v.segment_base?.initialization || '0-0'}" />
           </SegmentBase>
@@ -131,11 +227,10 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
       videoAdaptations = `<AdaptationSet contentType="video" mimeType="video/mp4" segmentAlignment="true">${reps}</AdaptationSet>`;
     }
     let audioAdaptations = '';
-    if (dash.audio?.length > 0) {
-      const reps = dash.audio.map(a => {
-        const baseUrl = a.baseUrl || a.base_url || '';
+    if (audioList.length > 0) {
+      const reps = audioList.map(a => {
         return `<Representation id="${a.id}" bandwidth="${a.bandwidth || 128000}" codecs="${a.codecs || 'mp4a.40.2'}" mimeType="${a.mimeType || 'audio/mp4'}">
-          <BaseURL>${escapeXml(baseUrl)}</BaseURL>
+          ${buildBaseUrls(a)}
           <SegmentBase indexRange="${a.SegmentBase?.indexRange || a.segment_base?.index_range || '0-0'}">
             <Initialization range="${a.SegmentBase?.Initialization || a.segment_base?.initialization || '0-0'}" />
           </SegmentBase>
@@ -152,6 +247,48 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
 
   function escapeXml(str) {
     return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+
+  // Emit primary + backup CDN URLs as multiple <BaseURL> elements so Shaka can
+  // fail over when a node returns bad/short data (the cause of the "Payload
+  // length does not match range requested bytes" + Shaka 1001 load failures).
+  //
+  // B站's primary baseUrl is usually a flaky PCDN/P2P node (mcdn.bilivideo.cn
+  // on a non-standard port), while a stable origin CDN (upos / *.bilivideo.com
+  // on :443) sits in backupUrl. Order origin FIRST so Shaka prefers it and only
+  // falls back to PCDN if the origin is unreachable.
+  function buildBaseUrls(rep) {
+    let urls = [];
+    const primary = rep.baseUrl || rep.base_url;
+    if (primary) urls.push(primary);
+    const backups = rep.backupUrl || rep.backup_url || [];
+    for (let i = 0; i < backups.length; i++) {
+      if (backups[i]) urls.push(backups[i]);
+    }
+    const seen = {};
+    urls = urls.filter(u => (seen[u] ? false : (seen[u] = true)));
+    const isPcdn = (u) => /mcdn\.|szbdyd|\bxy[\dx]+xy\b|:\d{4,5}\//i.test(u);
+    urls.sort((a, b) => (isPcdn(a) ? 1 : 0) - (isPcdn(b) ? 1 : 0));
+    return urls
+      .map(u => `<BaseURL>${escapeXml(u)}</BaseURL>`)
+      .join('\n          ') || '<BaseURL></BaseURL>';
+  }
+
+  // With ABR disabled, explicitly pin to the highest-bandwidth variant so the
+  // stream stays at the requested quality (B站 only returns variants <= the
+  // requested qn, so "highest" == the chosen quality ceiling).
+  function selectBestVariant(player) {
+    try {
+      const variants = player.getVariantTracks();
+      if (!variants || !variants.length) return;
+      const best = variants.reduce((a, b) => (b.bandwidth > a.bandwidth ? b : a));
+      const active = variants.find(v => v.active);
+      // load() already picks the first (highest) variant with ABR off — only
+      // switch if it isn't already best, and DON'T clear the buffer (avoids a
+      // wasteful full re-download that made loading slow).
+      if (active && active.id === best.id) return;
+      player.selectVariantTrack(best, /* clearBuffer */ false);
+    } catch (e) { /* ignore */ }
   }
 
   // Time update
@@ -174,6 +311,47 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
     }, 15000);
     return () => clearInterval(hb);
   }, [video?.bvid]);
+
+  // Stall watchdog: if playback freezes mid-video (segment error, network
+  // hiccup) and Shaka doesn't recover on its own, retry streaming; if it's
+  // still stuck, nudge currentTime to force a re-buffer.
+  // Fixes "plays halfway, freezes, and never resumes".
+  useEffect(() => {
+    let lastTime = -1;
+    let stalledSec = 0;
+    const iv = setInterval(() => {
+      const v = videoRef.current;
+      if (!v || v.paused || v.ended || v.seeking || v.readyState < 2) {
+        stalledSec = 0;
+        lastTime = v ? v.currentTime : -1;
+        return;
+      }
+      if (Math.abs(v.currentTime - lastTime) < 0.05) {
+        stalledSec += 1;
+        if (stalledSec === 3) {
+          console.warn('[watchdog] playback stalled 3s, retrying streaming');
+          try { shakaRef.current?.retryStreaming(); } catch {}
+        } else if (stalledSec >= 8) {
+          console.warn('[watchdog] still stalled, nudging currentTime');
+          try { v.currentTime = v.currentTime + 0.5; v.play(); } catch {}
+          stalledSec = 0;
+        }
+      } else {
+        stalledSec = 0;
+      }
+      lastTime = v.currentTime;
+    }, 1000);
+    return () => clearInterval(iv);
+  }, []);
+
+  // When focus returns to the tab row, scroll it back into view — the grid may
+  // have scrolled the panel down, leaving the tabs (and focus) off-screen.
+  useEffect(() => {
+    if (focusArea === 'tabs') {
+      const el = document.querySelector('.panel-tab-row');
+      if (el) el.scrollIntoView({ block: 'nearest' });
+    }
+  }, [focusArea]);
 
   // Auto-hide controls
   const hideControlsLater = useCallback(() => {
@@ -224,6 +402,44 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
     relatedSeenRef.current = new Set(relatedVideos.map(v => v.bvid).filter(Boolean));
   }, [relatedVideos.length === 0]);
 
+  // Load this uploader's videos (newest first) for the "UP主投稿" tab.
+  // reset=true starts fresh; otherwise appends the next page.
+  const loadUpVideos = useCallback(async (reset) => {
+    if (upLoadingRef.current) return;
+    let mid = upMidRef.current;
+    // The list item may not have carried owner.mid — resolve it lazily.
+    if (!mid && video?.bvid) {
+      try {
+        const info = await getVideoInfo(video.bvid);
+        mid = info?.data?.owner?.mid || null;
+        upMidRef.current = mid;
+        if (info?.data?.owner?.name) setUpName(info.data.owner.name);
+      } catch {}
+    }
+    if (!mid) return;
+    upLoadingRef.current = true;
+    try {
+      if (reset) { upPnRef.current = 1; upSeenRef.current = new Set(); }
+      const res = await getUpVideos(mid, upPnRef.current, 30);
+      const vlist = (res?.data?.list?.vlist) || [];
+      const mapped = vlist.filter(v => v.bvid && !upSeenRef.current.has(v.bvid)).map(v => {
+        upSeenRef.current.add(v.bvid);
+        return {
+          bvid: v.bvid,
+          title: v.title,
+          pic: v.pic,
+          owner: { name: v.author, mid: v.mid },
+          pubdate: v.created,
+        };
+      });
+      setUpVideos(prev => reset ? mapped : [...prev, ...mapped]);
+      upPnRef.current += 1;
+    } catch (e) {
+      console.warn('[loadUpVideos] failed:', e?.message || e);
+    }
+    upLoadingRef.current = false;
+  }, [video]);
+
   // Change quality
   const changeQuality = useCallback(async (qn) => {
     if (!video?.bvid || !shakaRef.current) return;
@@ -240,6 +456,7 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
         const mpdUrl = URL.createObjectURL(blob);
         await shakaRef.current.load(mpdUrl);
         URL.revokeObjectURL(mpdUrl);
+        selectBestVariant(shakaRef.current);
         videoRef.current.currentTime = pos;
         videoRef.current.play();
         setCurrentQuality(res?.data?.quality || qn);
@@ -316,10 +533,9 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
         }
         if (e.key === 'ArrowDown') {
           e.preventDefault();
-          if (relatedVideos.length > 0) {
+          if (relatedVideos.length > 0 || upMidRef.current) {
             setShowRelated(true);
-            setFocusArea('related');
-            setFocusIdx(0);
+            setFocusArea('tabs');
             if (controlsTimer.current) clearTimeout(controlsTimer.current);
           }
           return true;
@@ -384,9 +600,28 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
         }, 30);
       }
 
-      // === Related videos panel (4-column grid) ===
+      // === Tab row (相关推荐 / UP主投稿) ===
+      if (focusArea === 'tabs') {
+        e.preventDefault();
+        if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+          const next = panelTab === 'related' ? 'up' : 'related';
+          setPanelTab(next);
+          setFocusIdx(0);
+          if (next === 'up' && upVideos.length === 0) loadUpVideos(true);
+        } else if (e.key === 'ArrowUp') {
+          setFocusArea('controls');
+          setFocusIdx(0);
+        } else if (e.key === 'ArrowDown' || e.key === 'Enter') {
+          setFocusArea('related'); // enter the grid (shows the active tab's list)
+          setFocusIdx(0);
+        }
+        return true;
+      }
+
+      // === Video grid for the active tab (4-column) ===
       if (focusArea === 'related') {
         const RCOLS = 4;
+        const gridList = panelTab === 'up' ? upVideos : relatedVideos;
         if (e.key === 'ArrowLeft') {
           e.preventDefault();
           if (focusIdx % RCOLS > 0) {
@@ -397,7 +632,7 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
         }
         if (e.key === 'ArrowRight') {
           e.preventDefault();
-          if (focusIdx % RCOLS < RCOLS - 1 && focusIdx < relatedVideos.length - 1) {
+          if (focusIdx % RCOLS < RCOLS - 1 && focusIdx < gridList.length - 1) {
             setFocusIdx(prev => prev + 1);
             scrollRelatedIntoView(focusIdx + 1);
           }
@@ -410,42 +645,49 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
             setFocusIdx(newIdx);
             scrollRelatedIntoView(newIdx);
           } else {
-            setFocusArea('controls');
-            setFocusIdx(0);
+            setFocusArea('tabs'); // top row → back up to the tab bar
           }
           return true;
         }
         if (e.key === 'ArrowDown') {
           e.preventDefault();
           const nextIdx = focusIdx + RCOLS;
-          if (nextIdx < relatedVideos.length) {
+          if (nextIdx < gridList.length) {
             setFocusIdx(nextIdx);
             scrollRelatedIntoView(nextIdx);
           } else {
-            loadMoreRelated();
+            if (panelTab === 'up') loadUpVideos(false);
+            else loadMoreRelated();
           }
           return true;
         }
         if (e.key === 'Enter') {
           e.preventDefault();
-          const rv = relatedVideos[focusIdx];
+          const rv = gridList[focusIdx];
           if (rv && onPlayNext) onPlayNext(rv);
           return true;
         }
         return false;
       }
 
-      // === End screen ===
+      // === End screen (4-column grid) ===
       if (focusArea === 'endscreen') {
-        if (e.key === 'ArrowLeft') { e.preventDefault(); setFocusIdx(prev => Math.max(0, prev - 1)); return true; }
-        if (e.key === 'ArrowRight') { e.preventDefault(); setFocusIdx(prev => Math.min(relatedVideos.length - 1, prev + 1)); return true; }
-        if (e.key === 'Enter') {
-          e.preventDefault();
+        e.preventDefault();
+        const ECOLS = 4;
+        const n = Math.min(END_SCREEN_MAX, relatedVideos.length);
+        if (e.key === 'ArrowLeft') {
+          if (focusIdx % ECOLS > 0) setFocusIdx(focusIdx - 1);
+        } else if (e.key === 'ArrowRight') {
+          if (focusIdx % ECOLS < ECOLS - 1 && focusIdx < n - 1) setFocusIdx(focusIdx + 1);
+        } else if (e.key === 'ArrowUp') {
+          if (focusIdx >= ECOLS) setFocusIdx(focusIdx - ECOLS);
+        } else if (e.key === 'ArrowDown') {
+          if (focusIdx + ECOLS < n) setFocusIdx(focusIdx + ECOLS);
+        } else if (e.key === 'Enter') {
           const rv = relatedVideos[focusIdx];
           if (rv && onPlayNext) onPlayNext(rv);
-          return true;
         }
-        return false;
+        return true;
       }
 
       return false;
@@ -453,7 +695,7 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
 
     setCustomKeyHandler(handler);
     return () => setCustomKeyHandler(null);
-  }, [focusArea, focusIdx, qualities, showControls, showQuality, showRelated, ended, relatedVideos, onBack, onPlayNext, openControls, hideControlsLater, changeQuality]);
+  }, [focusArea, focusIdx, qualities, showControls, showQuality, showRelated, ended, relatedVideos, panelTab, upVideos, loadUpVideos, onBack, onPlayNext, openControls, hideControlsLater, changeQuality]);
 
   const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
 
@@ -468,6 +710,15 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
           display: 'flex', alignItems: 'center', justifyContent: 'center',
           background: 'rgba(0,0,0,0.8)', zIndex: 50 }}>
           <div className="loading"><div className="loading-spinner" />加载中...</div>
+        </div>
+      )}
+
+      {loadError && !loading && (
+        <div style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%',
+          display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
+          gap: 16, background: 'rgba(0,0,0,0.85)', zIndex: 50 }}>
+          <div style={{ fontSize: 26, color: '#fff' }}>视频加载失败</div>
+          <div style={{ fontSize: 18, color: '#aaa' }}>该视频源节点异常,请按返回键重试或换一个视频</div>
         </div>
       )}
 
@@ -494,28 +745,55 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
           <span className="player-time">{formatDuration(currentTime)} / {formatDuration(duration)}</span>
         </div>
 
-        {/* Related videos panel (4-column grid below controls) */}
-        {showRelated && relatedVideos.length > 0 && (
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 14, marginTop: 16, paddingBottom: 10 }}>
-            {relatedVideos.map((rv, i) => {
-              const thumb = (rv.pic || '').startsWith('//') ? 'https:' + rv.pic : rv.pic;
+        {/* Tabbed panel below controls: 相关推荐 / UP主投稿 */}
+        {showRelated && (
+          <div style={{ marginTop: 16, paddingBottom: 10 }}>
+            <div className="panel-tab-row" style={{ display: 'flex', gap: 14, marginBottom: 12 }}>
+              {[['related', '相关推荐'], ['up', upName ? `UP主投稿 · ${upName}` : 'UP主投稿']].map(([key, label]) => (
+                <div key={key} style={{
+                  padding: '6px 18px', fontSize: 18, borderRadius: 6,
+                  color: panelTab === key ? '#fff' : '#aaa',
+                  background: panelTab === key ? '#00a1d6' : 'rgba(255,255,255,0.08)',
+                  outline: focusArea === 'tabs' && panelTab === key ? '3px solid #fff' : 'none',
+                }}>{label}</div>
+              ))}
+            </div>
+
+            {(() => {
+              const list = panelTab === 'up' ? upVideos : relatedVideos;
+              if (list.length === 0) {
+                return <div style={{ color: '#888', fontSize: 18, padding: '20px 4px' }}>
+                  {panelTab === 'up' ? (upMidRef.current ? '加载中…' : '暂无 UP 主信息') : '暂无相关推荐'}
+                </div>;
+              }
               return (
-                <div key={rv.bvid || i} className="related-card" onClick={() => onPlayNext?.(rv)}
-                  style={{
-                    cursor: 'pointer',
-                    outline: focusArea === 'related' && focusIdx === i ? '4px solid #00a1d6' : 'none',
-                    borderRadius: 6, overflow: 'hidden',
-                  }}>
-                  <div style={{ width: '100%', aspectRatio: '16/9', background: '#1a1a2e', borderRadius: 6, overflow: 'hidden' }}>
-                    {thumb && <img src={thumb} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />}
-                  </div>
-                  <div style={{ padding: '6px 4px', fontSize: 18, color: '#ccc', lineHeight: 1.3,
-                    overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 1, WebkitBoxOrient: 'vertical' }}>
-                    {rv.title}
-                  </div>
+                <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 14 }}>
+                  {list.map((rv, i) => {
+                    const thumb = proxyImg(rv.pic);
+                    return (
+                      <div key={rv.bvid || i} className="related-card" onClick={() => onPlayNext?.(rv)}
+                        style={{
+                          cursor: 'pointer',
+                          outline: focusArea === 'related' && focusIdx === i ? '4px solid #00a1d6' : 'none',
+                          borderRadius: 6, overflow: 'hidden',
+                        }}>
+                        <div style={{ width: '100%', aspectRatio: '16/9', background: '#1a1a2e', borderRadius: 6, overflow: 'hidden' }}>
+                          {thumb && <img src={thumb} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />}
+                        </div>
+                        <div style={{ padding: '6px 4px 0', fontSize: 18, color: '#ccc', lineHeight: 1.3,
+                          overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 1, WebkitBoxOrient: 'vertical' }}>
+                          {rv.title}
+                        </div>
+                        <div style={{ padding: '2px 4px 6px', fontSize: 14, color: '#888',
+                          overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>
+                          {[rv.owner?.name, formatTime(rv.pubdate)].filter(Boolean).join(' · ')}
+                        </div>
+                      </div>
+                    );
+                  })}
                 </div>
               );
-            })}
+            })()}
           </div>
         )}
       </div>
@@ -538,28 +816,41 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
           background: 'rgba(0,0,0,0.85)', zIndex: 60,
           display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
         }}>
-          <div style={{ fontSize: 28, color: '#fff', marginBottom: 30 }}>播放结束</div>
-          <div style={{ fontSize: 20, color: '#aaa', marginBottom: 20 }}>接下来播放</div>
-          <div style={{ display: 'flex', gap: 20 }}>
-            {relatedVideos.map((rv, i) => {
-              const thumb = (rv.pic || '').startsWith('//') ? 'https:' + rv.pic : rv.pic;
+          <div style={{ fontSize: 30, color: '#fff', marginBottom: 6 }}>播放结束</div>
+          <div style={{ fontSize: 20, color: '#999', marginBottom: 28 }}>接下来播放</div>
+          <div style={{
+            display: 'grid', gridTemplateColumns: 'repeat(4, 300px)', gap: '24px 24px',
+            justifyContent: 'center',
+          }}>
+            {relatedVideos.slice(0, END_SCREEN_MAX).map((rv, i) => {
+              const thumb = proxyImg(rv.pic);
+              const focused = focusArea === 'endscreen' && focusIdx === i;
               return (
                 <div key={rv.bvid || i} onClick={() => onPlayNext?.(rv)}
                   style={{
-                    width: 280, cursor: 'pointer',
-                    outline: focusArea === 'endscreen' && focusIdx === i ? '4px solid #00a1d6' : 'none',
+                    width: 300, cursor: 'pointer',
+                    background: focused ? '#1f2440' : 'transparent',
+                    outline: focused ? '4px solid #00a1d6' : 'none',
                     borderRadius: 8, overflow: 'hidden',
+                    transition: 'background 0.15s',
                   }}>
-                  <div style={{ width: '100%', aspectRatio: '16/9', background: '#1a1a2e', borderRadius: 8, overflow: 'hidden' }}>
+                  <div style={{ width: '100%', aspectRatio: '16/9', background: '#1a1a2e', overflow: 'hidden' }}>
                     {thumb && <img src={thumb} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />}
                   </div>
-                  <div style={{ padding: '8px 4px', fontSize: 14, color: '#ccc', lineHeight: 1.3,
-                    overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}>
+                  <div style={{ padding: '8px 8px 2px', fontSize: 15, color: '#eee', lineHeight: 1.35,
+                    overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', height: 42 }}>
                     {rv.title}
+                  </div>
+                  <div style={{ padding: '0 8px 10px', fontSize: 13, color: '#888',
+                    overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>
+                    {[rv.owner?.name, formatTime(rv.pubdate)].filter(Boolean).join(' · ')}
                   </div>
                 </div>
               );
             })}
+          </div>
+          <div style={{ marginTop: 24, fontSize: 16, color: '#666' }}>
+            ← → ↑ ↓ 选择 · OK 播放 · 返回键 退出
           </div>
         </div>
       )}

--- a/app/src/utils/follow.js
+++ b/app/src/utils/follow.js
@@ -1,0 +1,32 @@
+// Cache of the logged-in user's followed UP mids, for the "已关注" card badge.
+// Web relation API caps at ~250 followings, so this is best-effort.
+import { getNavInfo, getFollowings } from '../api/client';
+
+let followedSet = null;
+let loadedAt = 0;
+const TTL = 30 * 60 * 1000; // 30 min
+
+export function getFollowedSet() {
+  return followedSet || new Set();
+}
+
+export async function loadFollowedMids(force) {
+  if (!force && followedSet && (Date.now() - loadedAt) < TTL) return followedSet;
+  const set = new Set();
+  try {
+    const nav = await getNavInfo();
+    const mid = nav?.data?.mid;
+    if (!mid) return followedSet || set;
+    for (let pn = 1; pn <= 5; pn++) {
+      const res = await getFollowings(mid, pn, 50);
+      const list = (res?.data?.list) || [];
+      list.forEach(u => { if (u.mid) set.add(u.mid); });
+      if (list.length < 50) break;
+    }
+    followedSet = set;
+    loadedAt = Date.now();
+  } catch (e) {
+    console.warn('[follow] loadFollowedMids failed:', e?.message || e);
+  }
+  return followedSet || set;
+}

--- a/service/com.biliwebos.app.service/service.js
+++ b/service/com.biliwebos.app.service/service.js
@@ -13,6 +13,10 @@ var url = require('url');
 
 var service = new Service('com.biliwebos.app.service');
 
+// Reuse TLS connections to CDN hosts. The TV's CPU makes a fresh TLS handshake
+// per segment expensive; keep-alive cuts initial-load and seek latency a lot.
+var keepAliveAgent = new https.Agent({ keepAlive: true, maxSockets: 8, keepAliveMsecs: 15000 });
+
 // Cookie storage
 var COOKIE_FILE = path.join('/media/internal', 'bili_cookies.json');
 var storedCookies = {};
@@ -44,7 +48,11 @@ function isAllowedHost(host) {
 }
 
 // Make HTTPS request helper
-function makeRequest(parsedUrl, method, body, contentType, range, callback) {
+// forceIdentity: never request gzip/deflate. Required for the binary proxy
+// path (segments/images) which pipes bytes raw without forwarding
+// Content-Encoding — compressed bytes there corrupt the Range/Content-Length
+// and trigger Shaka's "Payload length does not match range requested bytes".
+function makeRequest(parsedUrl, method, body, contentType, range, forceIdentity, callback) {
   var hostname = parsedUrl.hostname;
   var port = parsedUrl.port ? parseInt(parsedUrl.port) : 443;
   var isCDN = hostname.indexOf('bilivideo') >= 0 || hostname.indexOf('akamaized') >= 0;
@@ -54,7 +62,7 @@ function makeRequest(parsedUrl, method, body, contentType, range, callback) {
     'Referer': 'https://www.bilibili.com/',
     'Accept': isCDN ? '*/*' : 'application/json, text/plain, */*',
     'Accept-Language': 'zh-CN,zh;q=0.9',
-    'Accept-Encoding': isCDN ? 'identity' : 'gzip, deflate',
+    'Accept-Encoding': (isCDN || forceIdentity) ? 'identity' : 'gzip, deflate',
     'Cookie': serializeCookies(storedCookies)
   };
   if (!isCDN) headers['Origin'] = 'https://www.bilibili.com';
@@ -66,10 +74,14 @@ function makeRequest(parsedUrl, method, body, contentType, range, callback) {
     path: parsedUrl.pathname + (parsedUrl.search || ''),
     method: method || 'GET',
     headers: headers,
-    rejectUnauthorized: false
+    rejectUnauthorized: false,
+    agent: keepAliveAgent
   };
 
+  var done = false;
   var req = https.request(options, function (res) {
+    if (done) return;
+    done = true;
     var setCookieHeaders = res.headers['set-cookie'];
     if (setCookieHeaders) {
       setCookieHeaders.forEach(function (sc) {
@@ -84,7 +96,11 @@ function makeRequest(parsedUrl, method, body, contentType, range, callback) {
     callback(null, res);
   });
 
-  req.on('error', function (err) { callback(err); });
+  // Without a timeout a stuck CDN socket hangs forever and the segment never
+  // returns, freezing playback permanently. Bail out so the caller can fail
+  // the request and Shaka can retry.
+  req.setTimeout(10000, function () { req.destroy(new Error('Upstream timeout')); });
+  req.on('error', function (err) { if (done) return; done = true; callback(err); });
   if (body) req.write(body);
   req.end();
 }
@@ -124,7 +140,7 @@ service.register('fetch', function (message) {
   }
 
   makeRequest(parsed, message.payload.method, message.payload.body,
-    message.payload.contentType, message.payload.range, function (err, res) {
+    message.payload.contentType, message.payload.range, false, function (err, res) {
       if (err) { message.respond({ returnValue: false, error: err.message }); return; }
 
       decompressResponse(res, function (data) {
@@ -208,10 +224,9 @@ var localServer = http.createServer(function (req, res) {
     return;
   }
 
-  makeRequest(parsed, req.method, null, null, req.headers['range'], function (err, proxyRes) {
+  makeRequest(parsed, req.method, null, null, req.headers['range'], true, function (err, proxyRes) {
     if (err) {
-      res.writeHead(502);
-      res.end(err.message);
+      if (!res.headersSent) { res.writeHead(502); res.end(err.message); }
       return;
     }
 
@@ -225,6 +240,12 @@ var localServer = http.createServer(function (req, res) {
 
     res.writeHead(proxyRes.statusCode, responseHeaders);
     proxyRes.pipe(res);
+
+    // If the upstream errors/truncates mid-stream, tear down the client
+    // response (a half-delivered segment is what Shaka chokes on); if the
+    // client disconnects, free the upstream socket.
+    proxyRes.on('error', function () { res.destroy(); });
+    res.on('close', function () { proxyRes.destroy(); });
   });
 });
 

--- a/tools/drive.mjs
+++ b/tools/drive.mjs
@@ -1,0 +1,94 @@
+// Drive the TV app via CDP: inject remote-control key events, then screenshot.
+// Usage: node tools/drive.mjs "<keys>" [outfile] [pass] [perKeyMs]
+//   keys: comma-separated — up,down,left,right,ok,back,home (home=many lefts)
+//   e.g. node tools/drive.mjs "down,down,right" up.png
+// Lets Claude operate + verify the app without a human.
+import { Client } from 'ssh2';
+import { readFileSync, writeFileSync } from 'fs';
+import http from 'http';
+import net from 'net';
+import { WebSocket } from 'ws';
+
+const TV = { host: '192.168.50.94', port: 9922 };
+const KEYSEQ = (process.argv[2] || '').split(',').map(s => s.trim()).filter(Boolean);
+const OUT = process.argv[3] || 'drive.png';
+const PASS = process.argv[4] || '4E7082';
+const PER_KEY_MS = parseInt(process.argv[5]) || 450;
+
+const KEYMAP = {
+  up: { key: 'ArrowUp', code: 'ArrowUp', vk: 38 },
+  down: { key: 'ArrowDown', code: 'ArrowDown', vk: 40 },
+  left: { key: 'ArrowLeft', code: 'ArrowLeft', vk: 37 },
+  right: { key: 'ArrowRight', code: 'ArrowRight', vk: 39 },
+  ok: { key: 'Enter', code: 'Enter', vk: 13 },
+  enter: { key: 'Enter', code: 'Enter', vk: 13 },
+  back: { key: 'Backspace', code: 'Backspace', vk: 8 },
+};
+
+const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+
+const conn = new Client();
+conn.on('ready', () => {
+  const server = net.createServer(s => {
+    conn.forwardOut('127.0.0.1', 0, '127.0.0.1', 9998, (err, rs) => {
+      if (err) { s.end(); return; } s.pipe(rs).pipe(s);
+    });
+  });
+  server.listen(19994, '127.0.0.1', () => {
+    http.get('http://127.0.0.1:19994/json', res => {
+      let d = ''; res.on('data', c => d += c);
+      res.on('end', async () => {
+        const app = JSON.parse(d).find(p => p.title?.includes('哔哩') || p.url?.includes('biliwebos'));
+        if (!app) { console.log('App not running'); process.exit(1); }
+        const ws = new WebSocket(app.webSocketDebuggerUrl.replace(/127\.0\.0\.1:\d+/, '127.0.0.1:19994'));
+        let id = 1;
+        const send = (method, params) => { ws.send(JSON.stringify({ id: id++, method, params: params || {} })); };
+        const call = (method, params) => new Promise(resolve => {
+          const myId = id;
+          send(method, params);
+          const h = (raw) => { const m = JSON.parse(raw); if (m.id === myId) { ws.off('message', h); resolve(m.result); } };
+          ws.on('message', h);
+        });
+
+        await new Promise(r => ws.on('open', r));
+        await call('Runtime.enable');
+
+        // Expand "home" → several lefts to get back to the sidebar
+        const seq = [];
+        for (const k of KEYSEQ) {
+          if (k === 'home') { for (let i = 0; i < 6; i++) seq.push('left'); }
+          else seq.push(k);
+        }
+
+        for (const k of seq) {
+          const m = KEYMAP[k];
+          if (!m) { console.log('unknown key: ' + k); continue; }
+          await call('Input.dispatchKeyEvent', { type: 'keyDown', key: m.key, code: m.code, windowsVirtualKeyCode: m.vk, nativeVirtualKeyCode: m.vk });
+          await call('Input.dispatchKeyEvent', { type: 'keyUp', key: m.key, code: m.code, windowsVirtualKeyCode: m.vk, nativeVirtualKeyCode: m.vk });
+          await sleep(PER_KEY_MS);
+        }
+
+        // Let the UI settle (loads/animations), then read state + screenshot.
+        await sleep(1200);
+        const diag = await call('Runtime.evaluate', { expression: `JSON.stringify({
+          focus: document.querySelector('.focused, [data-focus-id].focused')?.getAttribute('data-focus-id') || null,
+          v: (function(){var v=document.querySelector('video');return v?{t:+v.currentTime.toFixed(1),ready:v.readyState,paused:v.paused}:null;})(),
+          imgs: document.querySelectorAll('img').length,
+          brokenImgs: Array.from(document.querySelectorAll('img')).filter(i=>i.complete&&i.naturalWidth===0).length,
+        })`, returnByValue: true });
+        console.log('STATE: ' + (diag?.result?.value || 'n/a'));
+
+        const shot = await call('Page.captureScreenshot', { format: 'png' });
+        if (shot?.data) { writeFileSync(OUT, Buffer.from(shot.data, 'base64')); console.log('shot: ' + OUT); }
+        ws.close(); server.close(); conn.end(); process.exit(0);
+      });
+    });
+  });
+});
+conn.on('error', e => { console.error('SSH error:', e.message); process.exit(1); });
+conn.connect({
+  host: TV.host, port: TV.port, username: 'prisoner',
+  privateKey: readFileSync(process.env.HOME + '/.ssh/tv_webos'),
+  passphrase: PASS, algorithms: { serverHostKey: ['ssh-rsa'] },
+});
+setTimeout(() => { console.error('timeout'); process.exit(1); }, 60000);

--- a/tools/netcap.mjs
+++ b/tools/netcap.mjs
@@ -1,0 +1,90 @@
+// Capture network responses going through the local proxy (:7654) so we can
+// see the real CDN host + the proxy's HTTP status for each segment request.
+import { Client } from 'ssh2';
+import { readFileSync } from 'fs';
+import http from 'http';
+import net from 'net';
+
+const TV = { host: '192.168.50.94', port: 9922, user: 'prisoner' };
+const KEY = process.env.HOME + '/.ssh/tv_webos';
+const PASSPHRASE = process.argv[2] || '4E7082';
+const DURATION_MS = (parseInt(process.argv[3]) || 70) * 1000;
+const LOCAL_PORT = 19995;
+
+function ts() { return new Date().toISOString().slice(11, 19); }
+
+async function main() {
+  const conn = new Client();
+  await new Promise((resolve, reject) => {
+    conn.on('ready', resolve); conn.on('error', reject);
+    conn.connect({ host: TV.host, port: TV.port, username: TV.user,
+      privateKey: readFileSync(KEY), passphrase: PASSPHRASE,
+      algorithms: { serverHostKey: ['ssh-rsa'] } });
+  });
+  const server = net.createServer((s) => {
+    conn.forwardOut('127.0.0.1', LOCAL_PORT, '127.0.0.1', 9998, (err, rs) => {
+      if (err) { s.end(); return; } s.pipe(rs).pipe(s);
+    });
+  });
+  await new Promise(r => server.listen(LOCAL_PORT, '127.0.0.1', r));
+
+  const pages = await fetchJSON(`http://127.0.0.1:${LOCAL_PORT}/json`);
+  const appPage = pages.find(p => p.url?.includes('biliwebos') || p.title?.includes('哔哩'));
+  if (!appPage) { console.log('app page not found'); process.exit(1); }
+  const wsUrl = appPage.webSocketDebuggerUrl.replace(/127\.0\.0\.1:\d+/, `127.0.0.1:${LOCAL_PORT}`);
+  const { WebSocket } = await import('ws');
+  const ws = new WebSocket(wsUrl);
+  let id = 1;
+  const reqHost = {}; // requestId -> proxied host
+  const reqStart = {}; // requestId -> ms timestamp
+
+  ws.on('open', () => {
+    ws.send(JSON.stringify({ id: id++, method: 'Network.enable' }));
+    ws.send(JSON.stringify({ id: id++, method: 'Console.enable' }));
+    ws.send(JSON.stringify({ id: id++, method: 'Runtime.enable' }));
+    console.log(`[${ts()}] network+console capture ${DURATION_MS / 1000}s — retry the failing video now`);
+  });
+  ws.on('message', (data) => {
+    const msg = JSON.parse(data);
+    if (msg.method === 'Console.messageAdded') {
+      const m = msg.params?.message;
+      console.log(`[${ts()}] console.${m?.level}: ${m?.text}`);
+    }
+    if (msg.method === 'Runtime.exceptionThrown') {
+      console.log(`[${ts()}] EXCEPTION: ${msg.params?.exceptionDetails?.text}`);
+    }
+    if (msg.method === 'Network.requestWillBeSent') {
+      const url = msg.params?.request?.url || '';
+      if (url.includes('/proxy/')) {
+        const m = url.match(/\/proxy\/([^/]+)/);
+        reqHost[msg.params.requestId] = m ? m[1] : url.slice(0, 60);
+        reqStart[msg.params.requestId] = msg.params.timestamp * 1000; // s -> ms
+        const range = msg.params?.request?.headers?.Range || msg.params?.request?.headers?.range || '';
+        if (range) reqHost[msg.params.requestId] += ' ' + range;
+      }
+    }
+    if (msg.method === 'Network.loadingFinished') {
+      const host = reqHost[msg.params.requestId];
+      if (host) {
+        const dur = Math.round(msg.params.timestamp * 1000 - (reqStart[msg.params.requestId] || msg.params.timestamp * 1000));
+        const kb = Math.round((msg.params.encodedDataLength || 0) / 1024);
+        console.log(`[${ts()}] done ${dur}ms ${kb}KB ${host}`);
+      }
+    }
+    if (msg.method === 'Network.loadingFailed') {
+      const host = reqHost[msg.params.requestId];
+      if (host) console.log(`[${ts()}] FAILED ${host} — ${msg.params.errorText}`);
+    }
+  });
+
+  await new Promise(r => setTimeout(r, DURATION_MS));
+  ws.close(); server.close(); conn.end();
+  console.log(`[${ts()}] netcap done`); process.exit(0);
+}
+function fetchJSON(url) {
+  return new Promise((resolve, reject) => {
+    http.get(url, res => { let d = ''; res.on('data', c => d += c);
+      res.on('end', () => { try { resolve(JSON.parse(d)); } catch { reject(new Error('bad json')); } }); }).on('error', reject);
+  });
+}
+main().catch(e => { console.error('Fatal:', e.message); process.exit(1); });

--- a/tools/sh.mjs
+++ b/tools/sh.mjs
@@ -1,0 +1,24 @@
+// Run an arbitrary shell command on the TV over SSH and print its output.
+// Usage: node tools/sh.mjs "<command>" [passphrase]
+import { Client } from 'ssh2';
+import { readFileSync } from 'fs';
+
+const TV = { host: '192.168.50.94', port: 9922, user: 'prisoner' };
+const KEY = process.env.HOME + '/.ssh/tv_webos';
+const CMD = process.argv[2] || 'echo no-command';
+const PASSPHRASE = process.argv[3] || '4E7082';
+
+const conn = new Client();
+conn.on('ready', () => {
+  conn.exec(CMD, (err, stream) => {
+    if (err) { console.error(err.message); process.exit(1); }
+    stream.on('data', d => process.stdout.write(d));
+    stream.stderr.on('data', d => process.stderr.write(d));
+    stream.on('close', () => { conn.end(); process.exit(0); });
+  });
+}).on('error', e => { console.error('SSH error:', e.message); process.exit(1); })
+  .connect({
+    host: TV.host, port: TV.port, username: TV.user,
+    privateKey: readFileSync(KEY), passphrase: PASSPHRASE,
+    algorithms: { serverHostKey: ['ssh-rsa'] },
+  });

--- a/tools/watch.mjs
+++ b/tools/watch.mjs
@@ -1,0 +1,97 @@
+// Long-running log monitor for the TV app.
+// Captures console + runtime exceptions, timestamps each line, and flags
+// stall-related messages (Payload mismatch / Shaka error / watchdog / retry).
+import { Client } from 'ssh2';
+import { readFileSync } from 'fs';
+import http from 'http';
+import net from 'net';
+
+const TV = { host: '192.168.50.94', port: 9922, user: 'prisoner' };
+const KEY = process.env.HOME + '/.ssh/tv_webos';
+const PASSPHRASE = process.argv[2] || '4E7082';
+const DURATION_MS = (parseInt(process.argv[3]) || 300) * 1000;
+const REMOTE_DEBUG_PORT = 9998;
+const LOCAL_PORT = parseInt(process.argv[4]) || 19997;
+
+function ts() { return new Date().toISOString().slice(11, 19); }
+function flag(text) {
+  return /payload length|shaka error|watchdog|retrystreaming|stall|error|fail|fatal|buffer/i.test(text);
+}
+
+async function main() {
+  const conn = new Client();
+  await new Promise((resolve, reject) => {
+    conn.on('ready', resolve);
+    conn.on('error', reject);
+    conn.connect({
+      host: TV.host, port: TV.port, username: TV.user,
+      privateKey: readFileSync(KEY), passphrase: PASSPHRASE,
+      algorithms: { serverHostKey: ['ssh-rsa'] },
+    });
+  });
+
+  const server = net.createServer((localSocket) => {
+    conn.forwardOut('127.0.0.1', LOCAL_PORT, '127.0.0.1', REMOTE_DEBUG_PORT, (err, remoteStream) => {
+      if (err) { localSocket.end(); return; }
+      localSocket.pipe(remoteStream).pipe(localSocket);
+    });
+  });
+  await new Promise(r => server.listen(LOCAL_PORT, '127.0.0.1', r));
+
+  const pages = await fetchJSON(`http://127.0.0.1:${LOCAL_PORT}/json`);
+  const appPage = pages.find(p => p.url?.includes('biliwebos') || p.title?.includes('哔哩'));
+  if (!appPage) { console.log('App page not found'); process.exit(1); }
+
+  const wsUrl = appPage.webSocketDebuggerUrl.replace(/127\.0\.0\.1:\d+/, `127.0.0.1:${LOCAL_PORT}`);
+  const { WebSocket } = await import('ws');
+  const ws = new WebSocket(wsUrl);
+  let msgId = 1;
+
+  ws.on('open', () => {
+    ws.send(JSON.stringify({ id: msgId++, method: 'Console.enable' }));
+    ws.send(JSON.stringify({ id: msgId++, method: 'Runtime.enable' }));
+    console.log(`[${ts()}] monitoring for ${DURATION_MS / 1000}s — play a video now`);
+
+    // Poll playback position every 5s so we can see exactly when it freezes.
+    setInterval(() => {
+      ws.send(JSON.stringify({
+        id: 200, method: 'Runtime.evaluate',
+        params: { expression: `(function(){var v=document.querySelector('video');return v?JSON.stringify({t:+v.currentTime.toFixed(1),paused:v.paused,ended:v.ended,ready:v.readyState,buffered:v.buffered.length?+v.buffered.end(v.buffered.length-1).toFixed(1):0}):'no-video';})()` }
+      }));
+    }, 5000);
+  });
+
+  ws.on('message', (data) => {
+    const msg = JSON.parse(data);
+    if (msg.method === 'Console.messageAdded') {
+      const m = msg.params?.message;
+      const text = m?.text || '';
+      const mark = flag(text) ? ' <<<' : '';
+      console.log(`[${ts()}] console.${m?.level}: ${text}${mark}`);
+    }
+    if (msg.method === 'Runtime.exceptionThrown') {
+      const ex = msg.params?.exceptionDetails;
+      console.log(`[${ts()}] EXCEPTION: ${ex?.text} ${ex?.exception?.description || ''} <<<`);
+    }
+    if (msg.id === 200 && msg.result?.result?.value) {
+      console.log(`[${ts()}] video: ${msg.result.result.value}`);
+    }
+  });
+
+  ws.on('error', (e) => console.log(`[${ts()}] ws error: ${e.message}`));
+
+  await new Promise(r => setTimeout(r, DURATION_MS));
+  ws.close(); server.close(); conn.end();
+  console.log(`[${ts()}] monitor done`);
+  process.exit(0);
+}
+
+function fetchJSON(url) {
+  return new Promise((resolve, reject) => {
+    http.get(url, res => {
+      let d = ''; res.on('data', c => d += c);
+      res.on('end', () => { try { resolve(JSON.parse(d)); } catch { reject(new Error('Bad JSON')); } });
+    }).on('error', reject);
+  });
+}
+main().catch(e => { console.error('Fatal:', e.message); process.exit(1); });


### PR DESCRIPTION
## Summary
Fixes the mid-playback freeze and slow/black loads, plus several feature additions. All verified on a real LG webOS TV (via CDP self-driving).

### Playback fixes
- **Mid-play freeze / load failures**: B站's primary `baseUrl` is a flaky PCDN node (`*.mcdn.bilivideo.cn:8082`) that returns bad/short Range data → Shaka error → freeze. MPD now emits backup CDN URLs and **prefers the stable origin CDN** (upos/`*.bilivideo.com`) over PCDN, with failover.
- **Loading forever / black screen**: `player.load` now retries 3× (fresh playurl each time) and shows an error overlay instead of a black screen.
- **Slow loads (5-9s → <1s)**: removed an exponential retry backoff that made the `manifest-parser` phase wait ~7.5s; resume via `load(url, startTime)` instead of load-then-seek; emit only the highest-bitrate representation (ABR is off); local proxy gains keep-alive, a 10s upstream timeout, and forced `identity` encoding on the binary path.
- Stall watchdog + quality pinning (no silent bitrate downgrade).

### Features
- Player bottom panel is now tabbed: **相关推荐 / UP主投稿** (newest-first, lazy mid resolve).
- Upload time shown on related/UP cards; end screen redesigned (4-col grid + full D-pad nav).
- Home **关注** feed: offset-cursor pagination + newest-first sort.
- **已关注** badge on cards for followed UPs (logged-in).
- Card thumbnails proxied + resized (fixes thumbnails that failed to load).
- Restored missing `VideoRow.jsx` (repo did not build without it).

### Dev tools
- `tools/drive.mjs` (CDP key injection + screenshot), `netcap.mjs`, `watch.mjs`, `sh.mjs` for driving/diagnosing the app on-device without a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)