### PR TITLE
Playback reliability/features + Bilibili cast receiver (NVA)

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { initKeyboardNav, setFocus, onFocusChange } from './hooks/useFocus';
-import { getNavInfo } from './api/client';
+import { castAck, castSubscribe, getNavInfo } from './api/client';
 import { storage } from './utils/storage';
 import SidebarItem from './components/SidebarItem';
 
@@ -82,6 +82,7 @@ export default function App() {
   const [showLogin, setShowLogin] = useState(false);
   const [toast, setToast] = useState('');
   const [refreshKey, setRefreshKey] = useState(0);
+  const pendingCastAckRef = useRef(null);
 
   useEffect(() => {
     initKeyboardNav();
@@ -92,6 +93,63 @@ export default function App() {
     }
     setTimeout(() => setFocus('content-0-0'), 500);
   }, []);
+
+  useEffect(() => {
+    const unsubscribe = castSubscribe(async (event) => {
+      if (!event || event.kind !== 'command' || !event.command) return;
+      const command = event.command;
+
+      if (command.type === 'play') {
+        pendingCastAckRef.current = command;
+        if (command.contentType === 'live') {
+          setPlayerVideo(null);
+          setLiveRoom({
+            roomid: command.roomId,
+            title: command.title || '投屏直播',
+            owner: { name: '' },
+          });
+        } else {
+          setLiveRoom(null);
+          setPlayerVideo({
+            aid: command.aid,
+            bvid: command.bvid,
+            cid: command.cid,
+            epid: command.epid,
+            title: command.title || '投屏视频',
+            owner: { name: '' },
+            fromCast: true,
+          });
+        }
+        return;
+      }
+
+      if (command.type === 'stop') {
+        window.dispatchEvent(new CustomEvent('bili-cast-command', { detail: command }));
+        setPlayerVideo(null);
+        setLiveRoom(null);
+        return;
+      }
+
+      window.dispatchEvent(new CustomEvent('bili-cast-command', { detail: command }));
+    }, (err) => {
+      console.error('Cast subscribe error:', err);
+    });
+
+    return () => unsubscribe?.();
+  }, []);
+
+  useEffect(() => {
+    const pending = pendingCastAckRef.current;
+    if (!pending) return;
+    if ((pending.contentType === 'video' && playerVideo) || (pending.contentType === 'live' && liveRoom)) {
+      castAck({
+        accepted: true,
+        command: pending,
+        at: Date.now(),
+      }).catch(() => {});
+      pendingCastAckRef.current = null;
+    }
+  }, [playerVideo, liveRoom]);
 
   useEffect(() => {
     const handleBack = () => {
@@ -182,7 +240,7 @@ export default function App() {
         {toast && <div className="toast">{toast}</div>}
       </div>
 
-      {playerVideo && <PlayerPage key={playerVideo.bvid} video={playerVideo} onBack={() => setPlayerVideo(null)} onPlayNext={(v) => setPlayerVideo(v)} />}
+      {playerVideo && <PlayerPage key={playerVideo.bvid || playerVideo.aid || playerVideo.cid} video={playerVideo} onBack={() => setPlayerVideo(null)} onPlayNext={(v) => setPlayerVideo(v)} />}
       {liveRoom && <LivePlayerPage key={liveRoom.roomid} room={liveRoom} onBack={() => setLiveRoom(null)} />}
 
       {showLogin && (

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -118,6 +118,7 @@ export default function App() {
             title: command.title || '投屏视频',
             owner: { name: '' },
             fromCast: true,
+            progress: Math.max(0, Number(command.seekTs || 0)),
           });
         }
         return;

--- a/app/src/api/client.js
+++ b/app/src/api/client.js
@@ -118,6 +118,66 @@ export async function rawFetch(url, options) {
   return proxyFetchRaw(url, options);
 }
 
+function lunaRequest(method, parameters, subscribe, handlers) {
+  handlers = handlers || {};
+  return new Promise(function(resolve, reject) {
+    if (!hasLunaService()) {
+      if (handlers.allowMissing) { resolve(null); return; }
+      reject(new Error('Luna not available'));
+      return;
+    }
+
+    window.webOS.service.request(SERVICE_URI, {
+      method: method,
+      subscribe: !!subscribe,
+      parameters: parameters || {},
+      onSuccess: function(res) {
+        if (handlers.onSuccess) handlers.onSuccess(res);
+        resolve(res);
+      },
+      onFailure: function(err) {
+        if (handlers.onFailure) handlers.onFailure(err);
+        reject(new Error(err.errorText || err.error || (method + ' failed')));
+      },
+    });
+  });
+}
+
+export function castSubscribe(onEvent, onFailure) {
+  if (!hasLunaService()) return function () {};
+
+  let cancelled = false;
+  window.webOS.service.request(SERVICE_URI, {
+    method: 'castSubscribe',
+    subscribe: true,
+    parameters: { subscribe: true },
+    onSuccess: function(res) {
+      if (!cancelled && res?.event && onEvent) onEvent(res.event, res.status);
+    },
+    onFailure: function(err) {
+      if (!cancelled && onFailure) onFailure(err);
+    }
+  });
+
+  return function () { cancelled = true; };
+}
+
+export async function castAck(payload) {
+  return lunaRequest('castAck', payload || {}, false, { allowMissing: true });
+}
+
+export async function castReportState(payload) {
+  return lunaRequest('castReportState', payload || {}, false, { allowMissing: true });
+}
+
+export async function castReportProgress(payload) {
+  return lunaRequest('castReportProgress', payload || {}, false, { allowMissing: true });
+}
+
+export async function castGetStatus() {
+  return lunaRequest('castGetStatus', {}, false, { allowMissing: true });
+}
+
 // ============ Login ============
 
 export async function qrCodeGenerate() {
@@ -150,14 +210,24 @@ export async function getRanking(rid, type) {
   return wbiFetch('/x/web-interface/ranking/v2', { rid: rid || 0, type: type || 'all' });
 }
 
-export async function getVideoInfo(bvid) {
-  return wbiFetch('/x/web-interface/view', { bvid: bvid });
+export async function getVideoInfo(video) {
+  if (typeof video === 'string') {
+    return wbiFetch('/x/web-interface/view', { bvid: video });
+  }
+  video = video || {};
+  if (video.bvid) return wbiFetch('/x/web-interface/view', { bvid: video.bvid });
+  if (video.aid) return wbiFetch('/x/web-interface/view', { aid: video.aid });
+  throw new Error('Missing video identifier');
 }
 
-export async function getPlayUrl(bvid, cid, qn) {
-  return wbiFetch('/x/player/playurl', {
-    bvid: bvid, cid: cid, qn: qn || 80, fnval: 4048, fnver: 0, fourk: 1, platform: 'pc',
-  });
+export async function getPlayUrl(videoOrBvid, cid, qn) {
+  var payload = {
+    cid: cid, qn: qn || 80, fnval: 4048, fnver: 0, fourk: 1, platform: 'pc',
+  };
+  if (typeof videoOrBvid === 'string') payload.bvid = videoOrBvid;
+  else if (videoOrBvid?.bvid) payload.bvid = videoOrBvid.bvid;
+  else if (videoOrBvid?.aid) payload.avid = videoOrBvid.aid;
+  return wbiFetch('/x/player/playurl', payload);
 }
 
 // Partition/region

--- a/app/src/api/client.js
+++ b/app/src/api/client.js
@@ -178,6 +178,11 @@ export async function castGetStatus() {
   return lunaRequest('castGetStatus', {}, false, { allowMissing: true });
 }
 
+// Rename the cast receiver as shown in the phone's 投屏 list (applies live).
+export async function castSetConfig(payload) {
+  return lunaRequest('castSetConfig', payload || {}, false, { allowMissing: true });
+}
+
 // ============ Login ============
 
 export async function qrCodeGenerate() {

--- a/app/src/api/client.js
+++ b/app/src/api/client.js
@@ -165,9 +165,17 @@ export async function getRegionDynamic(rid, pn, ps) {
   return wbiFetch('/x/web-interface/dynamic/region', { rid: rid || 0, pn: pn || 1, ps: ps || 6 });
 }
 
-// Follow feed
-export async function getFollowFeed(page, ps) {
-  return smartFetch(API_HOST, '/x/polymer/web-dynamic/v1/feed/all?timezone_offset=-480&type=video&page=' + (page || 1));
+// Follow feed — paginates by the `offset` cursor returned in data.offset,
+// NOT by page number (page alone re-returns the first page).
+export async function getFollowFeed(page, offset) {
+  var url = '/x/polymer/web-dynamic/v1/feed/all?timezone_offset=-480&type=video&page=' + (page || 1);
+  if (offset) url += '&offset=' + encodeURIComponent(offset);
+  return smartFetch(API_HOST, url);
+}
+
+// Logged-in user's followings (Cookie auth). Used to badge "已关注" on cards.
+export async function getFollowings(vmid, pn, ps) {
+  return apiFetch('/x/relation/followings', { vmid: vmid, pn: pn || 1, ps: ps || 50, order: 'desc' });
 }
 
 // ============ Live ============
@@ -294,4 +302,14 @@ function parseDanmakuXml(xml) {
 
 export async function getRelated(bvid) {
   return wbiFetch('/x/web-interface/archive/related', { bvid: bvid });
+}
+
+// ============ UP uploader ============
+
+// This uploader's submitted videos, newest first (space arc search, WBI signed)
+export async function getUpVideos(mid, pn, ps) {
+  return wbiFetch('/x/space/wbi/arc/search', {
+    mid: mid, pn: pn || 1, ps: ps || 30, order: 'pubdate', tid: 0, keyword: '',
+    platform: 'web', web_location: 1550101,
+  });
 }

--- a/app/src/components/VideoCard.jsx
+++ b/app/src/components/VideoCard.jsx
@@ -23,7 +23,7 @@ function proxyImg(url) {
   }
 }
 
-export default React.memo(function VideoCard({ video, focusId, row, col, group, onSelect }) {
+export default React.memo(function VideoCard({ video, focusId, row, col, group, onSelect, followed = false }) {
   const handleSelect = useCallback(() => {
     onSelect?.(video);
   }, [video, onSelect]);
@@ -59,6 +59,7 @@ export default React.memo(function VideoCard({ video, focusId, row, col, group, 
         <div className="video-card-title">{video.title}</div>
         <div className="video-card-meta">
           {video.owner?.name && <span>{video.owner.name}</span>}
+          {followed && <span style={{ color: '#00a1d6', fontWeight: 600 }}>已关注</span>}
           {video.stat?.view != null && <span>{formatCount(video.stat.view)}播放</span>}
           {video.play != null && <span>{formatCount(video.play)}播放</span>}
           {video.pubdate && <span>{formatTime(video.pubdate)}</span>}

--- a/app/src/components/VideoGrid.jsx
+++ b/app/src/components/VideoGrid.jsx
@@ -3,7 +3,7 @@ import VideoCard from './VideoCard';
 
 // Use transform:translateY for scrolling instead of overflow:scroll
 // This pushes scroll to GPU compositor, avoiding layout recalculation
-export default React.memo(function VideoGrid({ videos, group = 'content', startRow = 0, cols = 2, onSelect, focusRow = 0 }) {
+export default React.memo(function VideoGrid({ videos, group = 'content', startRow = 0, cols = 2, onSelect, focusRow = 0, followedMids = null }) {
   if (!videos || videos.length === 0) {
     return <div className="empty-state">暂无内容</div>;
   }
@@ -41,6 +41,7 @@ export default React.memo(function VideoGrid({ videos, group = 'content', startR
               col={col}
               group={group}
               onSelect={onSelect}
+              followed={!!(followedMids && video.owner?.mid && followedMids.has(video.owner.mid))}
             />
           );
         })}

--- a/app/src/components/VideoRow.jsx
+++ b/app/src/components/VideoRow.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import VideoCard from './VideoCard';
+
+export default React.memo(function VideoRow({ title, videos, rowIndex, group, onSelect }) {
+  return (
+    <div style={{ marginTop: 8 }}>
+      {title && <div className="section-title">{title}</div>}
+      <div style={{ display: 'flex', gap: 20, padding: '10px 36px', overflow: 'hidden' }}>
+        {videos.map((video, idx) => {
+          const bvid = video.bvid || video.bv_id;
+          return (
+            <VideoCard
+              key={bvid || `v-${rowIndex}-${idx}`}
+              video={video}
+              focusId={`${group}-${rowIndex}-${idx}`}
+              row={rowIndex}
+              col={idx}
+              group={group}
+              onSelect={onSelect}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+});

--- a/app/src/pages/HomePage.jsx
+++ b/app/src/pages/HomePage.jsx
@@ -2,18 +2,22 @@ import React, { useState, useEffect, useRef } from 'react';
 import { getPopular, getRecommend, getRegionDynamic, getFollowFeed, getLiveList } from '../api/client';
 import VideoGrid from '../components/VideoGrid';
 import { getCurrentFocusId, setFocus, onFocusChange } from '../hooks/useFocus';
+import { storage } from '../utils/storage';
+import { loadFollowedMids } from '../utils/follow';
 
 const COLS = 2;
 const FETCH_SIZE = 20;
 
-async function fetchByMode(mode, pn) {
+// Returns { items, offset } — offset is the follow-feed cursor (undefined for
+// other modes, which paginate by page number).
+async function fetchByMode(mode, pn, offset) {
   if (mode === 'hot') {
     const res = await getPopular(pn, FETCH_SIZE);
-    return res?.data?.list || [];
+    return { items: res?.data?.list || [] };
   } else if (mode === 'live') {
     const res = await getLiveList(pn, FETCH_SIZE);
     const items = res?.data?.list || res?.data?.recommend_room_list || [];
-    return items.map(item => ({
+    return { items: items.map(item => ({
       bvid: `live-${item.roomid}`,
       title: item.title,
       pic: item.cover || item.system_cover,
@@ -21,27 +25,29 @@ async function fetchByMode(mode, pn) {
       stat: { view: item.online || item.watched_show?.num },
       isLive: true,
       roomid: item.roomid,
-    }));
+    })) };
   } else if (mode === 'partition') {
     const rids = [1, 3, 4, 5, 17, 36, 160, 188, 211];
     const rid = rids[Math.floor(Math.random() * rids.length)];
     const res = await getRegionDynamic(rid, pn, FETCH_SIZE);
-    return res?.data?.archives || [];
+    return { items: res?.data?.archives || [] };
   } else if (mode === 'follow') {
-    const res = await getFollowFeed(pn, FETCH_SIZE);
-    return (res?.data?.items || []).map(item => {
+    const res = await getFollowFeed(pn, offset);
+    const items = (res?.data?.items || []).map(item => {
       const archive = item.modules?.module_dynamic?.major?.archive;
       if (!archive) return null;
       return {
         bvid: archive.bvid, title: archive.title, pic: archive.cover,
         duration: archive.duration_text, pubdate: archive.pubdate,
-        owner: { name: item.modules?.module_author?.name },
+        owner: { name: item.modules?.module_author?.name, mid: item.modules?.module_author?.mid },
         stat: { view: archive.stat?.play },
       };
     }).filter(Boolean);
+    items.sort((a, b) => (b.pubdate || 0) - (a.pubdate || 0)); // newest first
+    return { items, offset: res?.data?.offset };
   } else {
     const res = await getRecommend(4, FETCH_SIZE);
-    return res?.data?.item || [];
+    return { items: res?.data?.item || [] };
   }
 }
 
@@ -49,7 +55,9 @@ export default function HomePage({ onPlayVideo, refreshKey, mode = 'recommend' }
   const [videos, setVideos] = useState([]);
   const [loading, setLoading] = useState(true);
   const [focusRow, setFocusRow] = useState(0);
+  const [followedMids, setFollowedMids] = useState(null);
   const pageRef = useRef(1);
+  const offsetRef = useRef('');
   const seenRef = useRef(new Set());
   const fetchingRef = useRef(false);
 
@@ -58,15 +66,17 @@ export default function HomePage({ onPlayVideo, refreshKey, mode = 'recommend' }
     let cancelled = false;
     seenRef.current = new Set();
     pageRef.current = 1;
+    offsetRef.current = '';
     setLoading(true);
     setVideos([]);
     setFocusRow(0);
 
-    fetchByMode(mode, 1).then(items => {
+    fetchByMode(mode, 1, '').then(({ items, offset }) => {
       if (cancelled) return;
       setVideos(dedupe(items));
       setLoading(false);
       pageRef.current = 2;
+      offsetRef.current = offset || '';
       // Only focus content if not currently in sidebar
       setTimeout(() => {
         const cur = getCurrentFocusId();
@@ -78,6 +88,13 @@ export default function HomePage({ onPlayVideo, refreshKey, mode = 'recommend' }
 
     return () => { cancelled = true; };
   }, [refreshKey, mode]);
+
+  // Load followed UP mids once (logged-in only) to badge "已关注" on cards
+  useEffect(() => {
+    if (storage.getAuth()?.SESSDATA) {
+      loadFollowedMids().then(set => { if (set && set.size) setFollowedMids(set); });
+    }
+  }, []);
 
   function dedupe(items) {
     return items.filter(v => {
@@ -101,10 +118,11 @@ export default function HomePage({ onPlayVideo, refreshKey, mode = 'recommend' }
       const totalRows = Math.ceil(videos.length / COLS);
       if (row >= totalRows - 2 && !fetchingRef.current) {
         fetchingRef.current = true;
-        fetchByMode(mode, pageRef.current).then(items => {
+        fetchByMode(mode, pageRef.current, offsetRef.current).then(({ items, offset }) => {
           const unique = dedupe(items);
           if (unique.length > 0) setVideos(prev => [...prev, ...unique]);
           pageRef.current++;
+          if (offset) offsetRef.current = offset;
           fetchingRef.current = false;
         }).catch(() => { fetchingRef.current = false; });
       }
@@ -123,6 +141,7 @@ export default function HomePage({ onPlayVideo, refreshKey, mode = 'recommend' }
       cols={COLS}
       onSelect={onPlayVideo}
       focusRow={focusRow}
+      followedMids={followedMids}
     />
   );
 }

--- a/app/src/player/LivePlayerPage.jsx
+++ b/app/src/player/LivePlayerPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { getLiveStreamUrl } from '../api/client';
+import { getLiveStreamUrl, castReportState } from '../api/client';
 import { storage } from '../utils/storage';
 import { setCustomKeyHandler } from '../hooks/useFocus';
 
@@ -12,6 +12,7 @@ export default function LivePlayerPage({ room, onBack }) {
   useEffect(() => {
     async function load() {
       try {
+        castReportState({ playState: 'loading' }).catch(() => {});
         const hlsUrl = await getLiveStreamUrl(room.roomid);
         if (!hlsUrl || !videoRef.current) return;
 
@@ -25,17 +26,46 @@ export default function LivePlayerPage({ room, onBack }) {
         videoRef.current.src = proxied;
         videoRef.current.play();
         setLoading(false);
+        castReportState({ playState: 'playing' }).catch(() => {});
 
         // Hide info after 3s
         infoTimer.current = setTimeout(() => setShowInfo(false), 3000);
       } catch (err) {
         console.error('Live stream error:', err);
         setLoading(false);
+        castReportState({ playState: 'error', error: err?.message || 'live-load-failed' }).catch(() => {});
       }
     }
     load();
-    return () => { if (infoTimer.current) clearTimeout(infoTimer.current); };
+    return () => {
+      if (infoTimer.current) clearTimeout(infoTimer.current);
+      castReportState({ playState: 'stop' }).catch(() => {});
+    };
   }, [room.roomid]);
+
+  useEffect(() => {
+    const handleCastCommand = (event) => {
+      const command = event.detail;
+      if (!command) return;
+      if (command.type === 'stop') {
+        onBack?.();
+        return;
+      }
+      if (!videoRef.current) return;
+      if (command.type === 'pause') {
+        videoRef.current.pause();
+        castReportState({ playState: 'paused' }).catch(() => {});
+        return;
+      }
+      if (command.type === 'resume') {
+        videoRef.current.play();
+        castReportState({ playState: 'playing' }).catch(() => {});
+      }
+    };
+
+    window.addEventListener('bili-cast-command', handleCastCommand);
+    return () => window.removeEventListener('bili-cast-command', handleCastCommand);
+  }, [onBack]);
 
   // Key handler
   useEffect(() => {

--- a/app/src/player/PlayerPage.jsx
+++ b/app/src/player/PlayerPage.jsx
@@ -30,6 +30,29 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
   const cidRef = useRef(null);
   const startTimeRef = useRef(Date.now());
 
+  const pendingSeekRef = useRef(null);
+
+  const queueOrApplySeek = useCallback((seekSec) => {
+    const target = Math.max(0, Number(seekSec) || 0);
+    if (!videoRef.current) return;
+    const canSeekNow = Number.isFinite(videoRef.current.duration) && videoRef.current.duration > 0;
+    if (canSeekNow) {
+      const max = Math.max(0, (videoRef.current.duration || 0) - 0.2);
+      videoRef.current.currentTime = Math.min(target, max || target);
+      pendingSeekRef.current = null;
+      return;
+    }
+    pendingSeekRef.current = target;
+  }, []);
+
+  const flushPendingSeek = useCallback(() => {
+    if (pendingSeekRef.current == null || !videoRef.current) return;
+    if (!(Number.isFinite(videoRef.current.duration) && videoRef.current.duration > 0)) return;
+    const max = Math.max(0, (videoRef.current.duration || 0) - 0.2);
+    videoRef.current.currentTime = Math.min(pendingSeekRef.current, max || pendingSeekRef.current);
+    pendingSeekRef.current = null;
+  }, []);
+
   const CONTROLS = ['play', 'danmaku', 'quality'];
 
   // Initialize Shaka Player
@@ -90,8 +113,8 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
       await player.load(mpdUrl);
       URL.revokeObjectURL(mpdUrl);
 
-      if (video.progress && video.progress > 0 && video.progress < (dash.duration || 9999) - 10) {
-        videoRef.current.currentTime = video.progress;
+      if (video.progress && video.progress > 0) {
+        queueOrApplySeek(video.progress);
       }
 
       videoRef.current.play();
@@ -117,7 +140,7 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
       setLoading(false);
       castReportState({ playState: 'error', error: err?.message || 'load-failed' }).catch(() => {});
     }
-  }, [video]);
+  }, [video, queueOrApplySeek]);
 
   function buildMPD(dash) {
     const duration = dash.duration || 0;
@@ -184,6 +207,9 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
       setPlaying(true);
       castReportState({ playState: 'playing' }).catch(() => {});
     };
+    const handleLoadedMetadata = () => flushPendingSeek();
+    const handleCanPlay = () => flushPendingSeek();
+
     const handlePause = () => {
       if (!ended) castReportState({ playState: 'paused' }).catch(() => {});
       setPlaying(false);
@@ -191,11 +217,15 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
 
     el.addEventListener('play', handlePlay);
     el.addEventListener('pause', handlePause);
+    el.addEventListener('loadedmetadata', handleLoadedMetadata);
+    el.addEventListener('canplay', handleCanPlay);
     return () => {
       el.removeEventListener('play', handlePlay);
       el.removeEventListener('pause', handlePause);
+      el.removeEventListener('loadedmetadata', handleLoadedMetadata);
+      el.removeEventListener('canplay', handleCanPlay);
     };
-  }, [ended]);
+  }, [ended, flushPendingSeek]);
 
   useEffect(() => {
     return () => {
@@ -309,7 +339,7 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
         return;
       }
       if (command.type === 'seek') {
-        videoRef.current.currentTime = Math.max(0, command.positionSec || 0);
+        queueOrApplySeek(command.positionSec);
         castReportProgress({
           duration: Math.floor(videoRef.current.duration || 0),
           position: Math.floor(videoRef.current.currentTime || 0),
@@ -328,7 +358,7 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
 
     window.addEventListener('bili-cast-command', handleCastCommand);
     return () => window.removeEventListener('bili-cast-command', handleCastCommand);
-  }, [onBack]);
+  }, [onBack, queueOrApplySeek]);
 
   // ========== Keyboard handler ==========
   useEffect(() => {

--- a/app/src/player/PlayerPage.jsx
+++ b/app/src/player/PlayerPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { getPlayUrl, getDanmaku, getVideoInfo, reportHeartbeat, getRelated } from '../api/client';
+import { getPlayUrl, getDanmaku, getVideoInfo, reportHeartbeat, getRelated, castReportProgress, castReportState } from '../api/client';
 import { formatDuration, QUALITY_MAP } from '../utils/format';
 import { storage } from '../utils/storage';
 import { setCustomKeyHandler } from '../hooks/useFocus';
@@ -50,20 +50,22 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
   }, []);
 
   const loadVideo = useCallback(async (player) => {
-    if (!video?.bvid) return;
+    if (!video?.bvid && !video?.aid) return;
     setLoading(true);
+    castReportState({ playState: 'loading' }).catch(() => {});
     try {
       let cid = video.cid;
       if (!cid) {
-        const info = await getVideoInfo(video.bvid);
+        const info = await getVideoInfo(video);
         cid = info?.data?.cid;
         if (info?.data?.title) setVideoTitle(info.data.title);
+        if (!video.bvid && info?.data?.bvid) video.bvid = info.data.bvid;
       }
       if (!cid) return;
       cidRef.current = cid;
 
       const settings = storage.getSettings();
-      const res = await getPlayUrl(video.bvid, cid, settings.quality || 80);
+      const res = await getPlayUrl(video, cid, settings.quality || 80);
       const dash = res?.data?.dash;
       if (!dash) return;
 
@@ -95,12 +97,14 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
       videoRef.current.play();
       setPlaying(true);
       setLoading(false);
+      castReportState({ playState: 'playing' }).catch(() => {});
 
       videoRef.current.addEventListener('ended', () => {
         setEnded(true);
         setShowControls(true);
         setFocusArea('endscreen');
         setFocusIdx(0);
+        castReportState({ playState: 'end' }).catch(() => {});
       });
 
       try { setDanmakus(await getDanmaku(cid)); } catch {}
@@ -111,6 +115,7 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
     } catch (err) {
       console.error('Load video error:', err);
       setLoading(false);
+      castReportState({ playState: 'error', error: err?.message || 'load-failed' }).catch(() => {});
     }
   }, [video]);
 
@@ -158,11 +163,44 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
   useEffect(() => {
     timeUpdateRef.current = setInterval(() => {
       if (videoRef.current) {
-        setCurrentTime(videoRef.current.currentTime);
-        setDuration(videoRef.current.duration || 0);
+        const nextCurrentTime = videoRef.current.currentTime;
+        const nextDuration = videoRef.current.duration || 0;
+        setCurrentTime(nextCurrentTime);
+        setDuration(nextDuration);
+        castReportProgress({
+          duration: Math.floor(nextDuration),
+          position: Math.floor(nextCurrentTime),
+        }).catch(() => {});
       }
     }, 500);
     return () => clearInterval(timeUpdateRef.current);
+  }, []);
+
+  useEffect(() => {
+    const el = videoRef.current;
+    if (!el) return;
+
+    const handlePlay = () => {
+      setPlaying(true);
+      castReportState({ playState: 'playing' }).catch(() => {});
+    };
+    const handlePause = () => {
+      if (!ended) castReportState({ playState: 'paused' }).catch(() => {});
+      setPlaying(false);
+    };
+
+    el.addEventListener('play', handlePlay);
+    el.addEventListener('pause', handlePause);
+    return () => {
+      el.removeEventListener('play', handlePlay);
+      el.removeEventListener('pause', handlePause);
+    };
+  }, [ended]);
+
+  useEffect(() => {
+    return () => {
+      castReportState({ playState: 'stop' }).catch(() => {});
+    };
   }, []);
 
   // Heartbeat
@@ -226,12 +264,12 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
 
   // Change quality
   const changeQuality = useCallback(async (qn) => {
-    if (!video?.bvid || !shakaRef.current) return;
+    if ((!video?.bvid && !video?.aid) || !shakaRef.current) return;
     setCurrentQuality(qn);
     storage.setSettings({ ...storage.getSettings(), quality: qn });
     try {
       let cid = video.cid || cidRef.current;
-      const res = await getPlayUrl(video.bvid, cid, qn);
+      const res = await getPlayUrl(video, cid, qn);
       const dash = res?.data?.dash;
       if (dash) {
         const pos = videoRef.current.currentTime;
@@ -248,6 +286,49 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
       console.error('Quality change error:', e);
     }
   }, [video]);
+
+  useEffect(() => {
+    storage.setSettings({ ...storage.getSettings(), danmaku: danmakuEnabled });
+  }, [danmakuEnabled]);
+
+  useEffect(() => {
+    const handleCastCommand = (event) => {
+      const command = event.detail;
+      if (!command || !videoRef.current) return;
+
+      if (command.type === 'pause') {
+        videoRef.current.pause();
+        setPlaying(false);
+        castReportState({ playState: 'paused' }).catch(() => {});
+        return;
+      }
+      if (command.type === 'resume') {
+        videoRef.current.play();
+        setPlaying(true);
+        castReportState({ playState: 'playing' }).catch(() => {});
+        return;
+      }
+      if (command.type === 'seek') {
+        videoRef.current.currentTime = Math.max(0, command.positionSec || 0);
+        castReportProgress({
+          duration: Math.floor(videoRef.current.duration || 0),
+          position: Math.floor(videoRef.current.currentTime || 0),
+        }).catch(() => {});
+        return;
+      }
+      if (command.type === 'switchDanmaku') {
+        setDanmakuEnabled(!!command.open);
+        return;
+      }
+      if (command.type === 'stop') {
+        videoRef.current.pause();
+        onBack?.();
+      }
+    };
+
+    window.addEventListener('bili-cast-command', handleCastCommand);
+    return () => window.removeEventListener('bili-cast-command', handleCastCommand);
+  }, [onBack]);
 
   // ========== Keyboard handler ==========
   useEffect(() => {
@@ -338,8 +419,13 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
           e.preventDefault();
           const btn = CONTROLS[focusIdx];
           if (btn === 'play') {
-            if (videoRef.current.paused) { videoRef.current.play(); setPlaying(true); }
-            else { videoRef.current.pause(); setPlaying(false); }
+            if (videoRef.current.paused) {
+              videoRef.current.play(); setPlaying(true);
+              castReportState({ playState: 'playing' }).catch(() => {});
+            } else {
+              videoRef.current.pause(); setPlaying(false);
+              castReportState({ playState: 'paused' }).catch(() => {});
+            }
           } else if (btn === 'danmaku') {
             setDanmakuEnabled(prev => !prev);
           } else if (btn === 'quality') {

--- a/app/src/player/PlayerPage.jsx
+++ b/app/src/player/PlayerPage.jsx
@@ -1,9 +1,25 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { getPlayUrl, getDanmaku, getVideoInfo, reportHeartbeat, getRelated } from '../api/client';
-import { formatDuration, QUALITY_MAP } from '../utils/format';
+import { getPlayUrl, getDanmaku, getVideoInfo, reportHeartbeat, getRelated, getUpVideos } from '../api/client';
+import { formatDuration, formatTime, QUALITY_MAP } from '../utils/format';
 import { storage } from '../utils/storage';
 import { setCustomKeyHandler } from '../hooks/useFocus';
 import DanmakuLayer from './DanmakuLayer';
+
+// Proxy + resize card thumbnails (same as VideoCard): the proxy adds the
+// Referer B站 image CDN needs, and @672w webp keeps the TV's image decoder from
+// choking on full-size covers (which is why direct-loaded thumbs failed).
+function proxyImg(url) {
+  if (!url) return '';
+  let u = url.startsWith('//') ? 'https:' + url : url;
+  if (u.includes('hdslb.com') && !u.includes('@')) u += '@672w_420h_1c.webp';
+  const base = (typeof window !== 'undefined' && window.webOS) ? 'http://127.0.0.1:7654' : storage.getProxyUrl();
+  try {
+    const parsed = new URL(u);
+    return `${base}/proxy/${parsed.host}${parsed.pathname}${parsed.search}`;
+  } catch {
+    return u;
+  }
+}
 
 export default function PlayerPage({ video, onBack, onPlayNext }) {
   const videoRef = useRef(null);
@@ -20,17 +36,27 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
   const [danmakuEnabled, setDanmakuEnabled] = useState(true);
   const [videoTitle, setVideoTitle] = useState(video?.title || '');
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
   const [ended, setEnded] = useState(false);
   const [relatedVideos, setRelatedVideos] = useState([]);
-  // Focus: 'none' (no UI) | 'controls' | 'quality' | 'related' | 'endscreen'
+  // Bottom panel: 'related' (相关推荐) | 'up' (UP主投稿)
+  const [panelTab, setPanelTab] = useState('related');
+  const [upVideos, setUpVideos] = useState([]);
+  const [upName, setUpName] = useState('');
+  // Focus: 'none' | 'controls' | 'quality' | 'tabs' | 'related' (=grid) | 'endscreen'
   const [focusArea, setFocusArea] = useState('none');
   const [focusIdx, setFocusIdx] = useState(0);
   const controlsTimer = useRef(null);
   const timeUpdateRef = useRef(null);
   const cidRef = useRef(null);
   const startTimeRef = useRef(Date.now());
+  const upMidRef = useRef(null);
+  const upLoadingRef = useRef(false);
+  const upPnRef = useRef(1);
+  const upSeenRef = useRef(new Set());
 
   const CONTROLS = ['play', 'danmaku', 'quality'];
+  const END_SCREEN_MAX = 8; // up to 2 rows of 4 on the end screen
 
   // Initialize Shaka Player
   useEffect(() => {
@@ -42,7 +68,47 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
       const player = new shaka.Player();
       await player.attach(videoRef.current);
       shakaRef.current = player;
-      player.addEventListener('error', (e) => console.error('Shaka error:', e.detail));
+
+      // Resilience: more retries + longer timeouts so a flaky segment fetch is
+      // retried instead of fataling the whole playback (TV CDN is unreliable).
+      player.configure({
+        // ABR off: the app has an explicit quality selector, so don't let
+        // Shaka silently downgrade bitrate mid-playback on bandwidth wobble.
+        abr: { enabled: false },
+        // No exponential backoff: keep retries for reliability but a flat,
+        // short delay so a transient failure doesn't add seconds of dead wait
+        // (an aggressive backoff here added ~7.5s to every load).
+        manifest: { retryParameters: { maxAttempts: 4, baseDelay: 150, backoffFactor: 1, timeout: 15000 } },
+        streaming: {
+          retryParameters: { maxAttempts: 6, baseDelay: 200, backoffFactor: 1, fuzzFactor: 0.5, timeout: 20000 },
+          bufferingGoal: 30,
+          rebufferingGoal: 2,
+        },
+      });
+
+      // On a network/media error, resume streaming instead of dying silently.
+      // category 1 = NETWORK, 3 = MEDIA — usually recoverable mid-playback.
+      player.addEventListener('error', (e) => {
+        const err = e.detail;
+        console.error('Shaka error code:', err?.code, 'category:', err?.category, err);
+        if (err && (err.category === 1 || err.category === 3)) {
+          try { player.retryStreaming(); } catch {}
+        }
+      });
+
+      // Rewrite all media/segment URLs through the local proxy (TV) or Mac
+      // proxy. Registered once here — not per load — so retries don't stack
+      // duplicate filters.
+      player.getNetworkingEngine().registerRequestFilter((type, request) => {
+        if (request.uris[0] && request.uris[0].startsWith('http')) {
+          const originalUrl = new URL(request.uris[0]);
+          const proxyBase = (typeof window !== 'undefined' && window.webOS)
+            ? 'http://127.0.0.1:7654'
+            : storage.getProxyUrl();
+          request.uris[0] = `${proxyBase}/proxy/${originalUrl.host}${originalUrl.pathname}${originalUrl.search}`;
+        }
+      });
+
       if (mounted) loadVideo(player);
     }
     init();
@@ -52,46 +118,68 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
   const loadVideo = useCallback(async (player) => {
     if (!video?.bvid) return;
     setLoading(true);
+    setLoadError(false);
     try {
       let cid = video.cid;
+      let ownerMid = video.owner?.mid || null;
+      let ownerName = video.owner?.name || '';
       if (!cid) {
         const info = await getVideoInfo(video.bvid);
         cid = info?.data?.cid;
         if (info?.data?.title) setVideoTitle(info.data.title);
+        if (info?.data?.owner) {
+          ownerMid = ownerMid || info.data.owner.mid;
+          ownerName = ownerName || info.data.owner.name;
+        }
       }
-      if (!cid) return;
+      if (!cid) throw new Error('No cid for video');
       cidRef.current = cid;
+      // Reset the "UP主投稿" tab for this uploader
+      upMidRef.current = ownerMid;
+      upPnRef.current = 1;
+      upSeenRef.current = new Set();
+      setUpVideos([]);
+      setUpName(ownerName || '');
+      setPanelTab('related');
 
       const settings = storage.getSettings();
-      const res = await getPlayUrl(video.bvid, cid, settings.quality || 80);
-      const dash = res?.data?.dash;
-      if (!dash) return;
+      let loaded = false;
+      let lastErr = null;
+      // Re-fetch playurl + retry: a fresh playurl hands back different CDN
+      // nodes, and buildMPD now carries backup URLs, so a bad node fails over
+      // instead of leaving a black "loading forever" screen.
+      for (let attempt = 0; attempt < 3 && !loaded; attempt++) {
+        try {
+          const res = await getPlayUrl(video.bvid, cid, settings.quality || 80);
+          const dash = res?.data?.dash;
+          if (!dash) throw new Error('No DASH stream in playurl (DRM/bangumi?)');
 
-      setQualities((res?.data?.accept_quality || []).map(q => ({ qn: q, label: QUALITY_MAP[q] || `${q}` })));
-      setCurrentQuality(res?.data?.quality || 80);
+          setQualities((res?.data?.accept_quality || []).map(q => ({ qn: q, label: QUALITY_MAP[q] || `${q}` })));
+          setCurrentQuality(res?.data?.quality || 80);
 
-      const mpd = buildMPD(dash);
-      const blob = new Blob([mpd], { type: 'application/dash+xml' });
-      const mpdUrl = URL.createObjectURL(blob);
-
-      player.getNetworkingEngine().registerRequestFilter((type, request) => {
-        if (request.uris[0].startsWith('http')) {
-          const originalUrl = new URL(request.uris[0]);
-          // Use local proxy on TV (JS Service), fallback to Mac proxy
-          const proxyBase = (typeof window !== 'undefined' && window.webOS)
-            ? 'http://127.0.0.1:7654'
-            : storage.getProxyUrl();
-          request.uris[0] = `${proxyBase}/proxy/${originalUrl.host}${originalUrl.pathname}${originalUrl.search}`;
+          const mpd = buildMPD(dash);
+          const blob = new Blob([mpd], { type: 'application/dash+xml' });
+          const mpdUrl = URL.createObjectURL(blob);
+          // Resume directly at the saved position via load()'s startTime — don't
+          // load at 0 then seek, which buffers the intro and immediately throws
+          // it away (the main cause of the long resume-load wait).
+          const resumeAt = (video.progress && video.progress > 0 && video.progress < (dash.duration || 9999) - 10)
+            ? video.progress : 0;
+          try {
+            await player.load(mpdUrl, resumeAt || undefined);
+          } finally {
+            URL.revokeObjectURL(mpdUrl);
+          }
+          loaded = true;
+        } catch (e) {
+          lastErr = e;
+          console.warn('[loadVideo] attempt ' + (attempt + 1) + ' failed:', e?.message || e);
+          if (attempt < 2) await new Promise(r => setTimeout(r, 800));
         }
-      });
-
-      await player.load(mpdUrl);
-      URL.revokeObjectURL(mpdUrl);
-
-      if (video.progress && video.progress > 0 && video.progress < (dash.duration || 9999) - 10) {
-        videoRef.current.currentTime = video.progress;
       }
+      if (!loaded) throw lastErr || new Error('Playback load failed');
 
+      selectBestVariant(player);
       videoRef.current.play();
       setPlaying(true);
       setLoading(false);
@@ -109,20 +197,28 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
         setRelatedVideos((rel?.data || []).slice(0, 12));
       } catch {}
     } catch (err) {
-      console.error('Load video error:', err);
+      console.error('Load video error:', err?.message || err);
       setLoading(false);
+      setLoadError(true);
     }
   }, [video]);
 
   function buildMPD(dash) {
     const duration = dash.duration || 0;
     const minBuffer = dash.minBufferTime || 1.5;
+    // ABR is off and manual quality re-fetches playurl, so the MPD only needs
+    // the single highest-bitrate video + audio. Emitting every quality/codec
+    // (B站 returns AVC+HEVC+AV1 × resolutions) makes Shaka's parse/codec-probe
+    // on the TV's weak CPU take several seconds before the first byte loads.
+    const pickBest = (arr) => (arr && arr.length)
+      ? [arr.reduce((a, b) => ((b.bandwidth || 0) > (a.bandwidth || 0) ? b : a))] : [];
+    const videoList = pickBest(dash.video);
+    const audioList = pickBest(dash.audio);
     let videoAdaptations = '';
-    if (dash.video?.length > 0) {
-      const reps = dash.video.map(v => {
-        const baseUrl = v.baseUrl || v.base_url || '';
+    if (videoList.length > 0) {
+      const reps = videoList.map(v => {
         return `<Representation id="${v.id}" bandwidth="${v.bandwidth || 1000000}" codecs="${v.codecs || 'avc1.640032'}" mimeType="${v.mimeType || 'video/mp4'}" width="${v.width || 1920}" height="${v.height || 1080}" frameRate="${v.frameRate || v.frame_rate || '30'}">
-          <BaseURL>${escapeXml(baseUrl)}</BaseURL>
+          ${buildBaseUrls(v)}
           <SegmentBase indexRange="${v.SegmentBase?.indexRange || v.segment_base?.index_range || '0-0'}">
             <Initialization range="${v.SegmentBase?.Initialization || v.segment_base?.initialization || '0-0'}" />
           </SegmentBase>
@@ -131,11 +227,10 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
       videoAdaptations = `<AdaptationSet contentType="video" mimeType="video/mp4" segmentAlignment="true">${reps}</AdaptationSet>`;
     }
     let audioAdaptations = '';
-    if (dash.audio?.length > 0) {
-      const reps = dash.audio.map(a => {
-        const baseUrl = a.baseUrl || a.base_url || '';
+    if (audioList.length > 0) {
+      const reps = audioList.map(a => {
         return `<Representation id="${a.id}" bandwidth="${a.bandwidth || 128000}" codecs="${a.codecs || 'mp4a.40.2'}" mimeType="${a.mimeType || 'audio/mp4'}">
-          <BaseURL>${escapeXml(baseUrl)}</BaseURL>
+          ${buildBaseUrls(a)}
           <SegmentBase indexRange="${a.SegmentBase?.indexRange || a.segment_base?.index_range || '0-0'}">
             <Initialization range="${a.SegmentBase?.Initialization || a.segment_base?.initialization || '0-0'}" />
           </SegmentBase>
@@ -152,6 +247,48 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
 
   function escapeXml(str) {
     return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+
+  // Emit primary + backup CDN URLs as multiple <BaseURL> elements so Shaka can
+  // fail over when a node returns bad/short data (the cause of the "Payload
+  // length does not match range requested bytes" + Shaka 1001 load failures).
+  //
+  // B站's primary baseUrl is usually a flaky PCDN/P2P node (mcdn.bilivideo.cn
+  // on a non-standard port), while a stable origin CDN (upos / *.bilivideo.com
+  // on :443) sits in backupUrl. Order origin FIRST so Shaka prefers it and only
+  // falls back to PCDN if the origin is unreachable.
+  function buildBaseUrls(rep) {
+    let urls = [];
+    const primary = rep.baseUrl || rep.base_url;
+    if (primary) urls.push(primary);
+    const backups = rep.backupUrl || rep.backup_url || [];
+    for (let i = 0; i < backups.length; i++) {
+      if (backups[i]) urls.push(backups[i]);
+    }
+    const seen = {};
+    urls = urls.filter(u => (seen[u] ? false : (seen[u] = true)));
+    const isPcdn = (u) => /mcdn\.|szbdyd|\bxy[\dx]+xy\b|:\d{4,5}\//i.test(u);
+    urls.sort((a, b) => (isPcdn(a) ? 1 : 0) - (isPcdn(b) ? 1 : 0));
+    return urls
+      .map(u => `<BaseURL>${escapeXml(u)}</BaseURL>`)
+      .join('\n          ') || '<BaseURL></BaseURL>';
+  }
+
+  // With ABR disabled, explicitly pin to the highest-bandwidth variant so the
+  // stream stays at the requested quality (B站 only returns variants <= the
+  // requested qn, so "highest" == the chosen quality ceiling).
+  function selectBestVariant(player) {
+    try {
+      const variants = player.getVariantTracks();
+      if (!variants || !variants.length) return;
+      const best = variants.reduce((a, b) => (b.bandwidth > a.bandwidth ? b : a));
+      const active = variants.find(v => v.active);
+      // load() already picks the first (highest) variant with ABR off — only
+      // switch if it isn't already best, and DON'T clear the buffer (avoids a
+      // wasteful full re-download that made loading slow).
+      if (active && active.id === best.id) return;
+      player.selectVariantTrack(best, /* clearBuffer */ false);
+    } catch (e) { /* ignore */ }
   }
 
   // Time update
@@ -174,6 +311,47 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
     }, 15000);
     return () => clearInterval(hb);
   }, [video?.bvid]);
+
+  // Stall watchdog: if playback freezes mid-video (segment error, network
+  // hiccup) and Shaka doesn't recover on its own, retry streaming; if it's
+  // still stuck, nudge currentTime to force a re-buffer.
+  // Fixes "plays halfway, freezes, and never resumes".
+  useEffect(() => {
+    let lastTime = -1;
+    let stalledSec = 0;
+    const iv = setInterval(() => {
+      const v = videoRef.current;
+      if (!v || v.paused || v.ended || v.seeking || v.readyState < 2) {
+        stalledSec = 0;
+        lastTime = v ? v.currentTime : -1;
+        return;
+      }
+      if (Math.abs(v.currentTime - lastTime) < 0.05) {
+        stalledSec += 1;
+        if (stalledSec === 3) {
+          console.warn('[watchdog] playback stalled 3s, retrying streaming');
+          try { shakaRef.current?.retryStreaming(); } catch {}
+        } else if (stalledSec >= 8) {
+          console.warn('[watchdog] still stalled, nudging currentTime');
+          try { v.currentTime = v.currentTime + 0.5; v.play(); } catch {}
+          stalledSec = 0;
+        }
+      } else {
+        stalledSec = 0;
+      }
+      lastTime = v.currentTime;
+    }, 1000);
+    return () => clearInterval(iv);
+  }, []);
+
+  // When focus returns to the tab row, scroll it back into view — the grid may
+  // have scrolled the panel down, leaving the tabs (and focus) off-screen.
+  useEffect(() => {
+    if (focusArea === 'tabs') {
+      const el = document.querySelector('.panel-tab-row');
+      if (el) el.scrollIntoView({ block: 'nearest' });
+    }
+  }, [focusArea]);
 
   // Auto-hide controls
   const hideControlsLater = useCallback(() => {
@@ -224,6 +402,44 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
     relatedSeenRef.current = new Set(relatedVideos.map(v => v.bvid).filter(Boolean));
   }, [relatedVideos.length === 0]);
 
+  // Load this uploader's videos (newest first) for the "UP主投稿" tab.
+  // reset=true starts fresh; otherwise appends the next page.
+  const loadUpVideos = useCallback(async (reset) => {
+    if (upLoadingRef.current) return;
+    let mid = upMidRef.current;
+    // The list item may not have carried owner.mid — resolve it lazily.
+    if (!mid && video?.bvid) {
+      try {
+        const info = await getVideoInfo(video.bvid);
+        mid = info?.data?.owner?.mid || null;
+        upMidRef.current = mid;
+        if (info?.data?.owner?.name) setUpName(info.data.owner.name);
+      } catch {}
+    }
+    if (!mid) return;
+    upLoadingRef.current = true;
+    try {
+      if (reset) { upPnRef.current = 1; upSeenRef.current = new Set(); }
+      const res = await getUpVideos(mid, upPnRef.current, 30);
+      const vlist = (res?.data?.list?.vlist) || [];
+      const mapped = vlist.filter(v => v.bvid && !upSeenRef.current.has(v.bvid)).map(v => {
+        upSeenRef.current.add(v.bvid);
+        return {
+          bvid: v.bvid,
+          title: v.title,
+          pic: v.pic,
+          owner: { name: v.author, mid: v.mid },
+          pubdate: v.created,
+        };
+      });
+      setUpVideos(prev => reset ? mapped : [...prev, ...mapped]);
+      upPnRef.current += 1;
+    } catch (e) {
+      console.warn('[loadUpVideos] failed:', e?.message || e);
+    }
+    upLoadingRef.current = false;
+  }, [video]);
+
   // Change quality
   const changeQuality = useCallback(async (qn) => {
     if (!video?.bvid || !shakaRef.current) return;
@@ -240,6 +456,7 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
         const mpdUrl = URL.createObjectURL(blob);
         await shakaRef.current.load(mpdUrl);
         URL.revokeObjectURL(mpdUrl);
+        selectBestVariant(shakaRef.current);
         videoRef.current.currentTime = pos;
         videoRef.current.play();
         setCurrentQuality(res?.data?.quality || qn);
@@ -316,10 +533,9 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
         }
         if (e.key === 'ArrowDown') {
           e.preventDefault();
-          if (relatedVideos.length > 0) {
+          if (relatedVideos.length > 0 || upMidRef.current) {
             setShowRelated(true);
-            setFocusArea('related');
-            setFocusIdx(0);
+            setFocusArea('tabs');
             if (controlsTimer.current) clearTimeout(controlsTimer.current);
           }
           return true;
@@ -384,9 +600,28 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
         }, 30);
       }
 
-      // === Related videos panel (4-column grid) ===
+      // === Tab row (相关推荐 / UP主投稿) ===
+      if (focusArea === 'tabs') {
+        e.preventDefault();
+        if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+          const next = panelTab === 'related' ? 'up' : 'related';
+          setPanelTab(next);
+          setFocusIdx(0);
+          if (next === 'up' && upVideos.length === 0) loadUpVideos(true);
+        } else if (e.key === 'ArrowUp') {
+          setFocusArea('controls');
+          setFocusIdx(0);
+        } else if (e.key === 'ArrowDown' || e.key === 'Enter') {
+          setFocusArea('related'); // enter the grid (shows the active tab's list)
+          setFocusIdx(0);
+        }
+        return true;
+      }
+
+      // === Video grid for the active tab (4-column) ===
       if (focusArea === 'related') {
         const RCOLS = 4;
+        const gridList = panelTab === 'up' ? upVideos : relatedVideos;
         if (e.key === 'ArrowLeft') {
           e.preventDefault();
           if (focusIdx % RCOLS > 0) {
@@ -397,7 +632,7 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
         }
         if (e.key === 'ArrowRight') {
           e.preventDefault();
-          if (focusIdx % RCOLS < RCOLS - 1 && focusIdx < relatedVideos.length - 1) {
+          if (focusIdx % RCOLS < RCOLS - 1 && focusIdx < gridList.length - 1) {
             setFocusIdx(prev => prev + 1);
             scrollRelatedIntoView(focusIdx + 1);
           }
@@ -410,42 +645,49 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
             setFocusIdx(newIdx);
             scrollRelatedIntoView(newIdx);
           } else {
-            setFocusArea('controls');
-            setFocusIdx(0);
+            setFocusArea('tabs'); // top row → back up to the tab bar
           }
           return true;
         }
         if (e.key === 'ArrowDown') {
           e.preventDefault();
           const nextIdx = focusIdx + RCOLS;
-          if (nextIdx < relatedVideos.length) {
+          if (nextIdx < gridList.length) {
             setFocusIdx(nextIdx);
             scrollRelatedIntoView(nextIdx);
           } else {
-            loadMoreRelated();
+            if (panelTab === 'up') loadUpVideos(false);
+            else loadMoreRelated();
           }
           return true;
         }
         if (e.key === 'Enter') {
           e.preventDefault();
-          const rv = relatedVideos[focusIdx];
+          const rv = gridList[focusIdx];
           if (rv && onPlayNext) onPlayNext(rv);
           return true;
         }
         return false;
       }
 
-      // === End screen ===
+      // === End screen (4-column grid) ===
       if (focusArea === 'endscreen') {
-        if (e.key === 'ArrowLeft') { e.preventDefault(); setFocusIdx(prev => Math.max(0, prev - 1)); return true; }
-        if (e.key === 'ArrowRight') { e.preventDefault(); setFocusIdx(prev => Math.min(relatedVideos.length - 1, prev + 1)); return true; }
-        if (e.key === 'Enter') {
-          e.preventDefault();
+        e.preventDefault();
+        const ECOLS = 4;
+        const n = Math.min(END_SCREEN_MAX, relatedVideos.length);
+        if (e.key === 'ArrowLeft') {
+          if (focusIdx % ECOLS > 0) setFocusIdx(focusIdx - 1);
+        } else if (e.key === 'ArrowRight') {
+          if (focusIdx % ECOLS < ECOLS - 1 && focusIdx < n - 1) setFocusIdx(focusIdx + 1);
+        } else if (e.key === 'ArrowUp') {
+          if (focusIdx >= ECOLS) setFocusIdx(focusIdx - ECOLS);
+        } else if (e.key === 'ArrowDown') {
+          if (focusIdx + ECOLS < n) setFocusIdx(focusIdx + ECOLS);
+        } else if (e.key === 'Enter') {
           const rv = relatedVideos[focusIdx];
           if (rv && onPlayNext) onPlayNext(rv);
-          return true;
         }
-        return false;
+        return true;
       }
 
       return false;
@@ -453,7 +695,7 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
 
     setCustomKeyHandler(handler);
     return () => setCustomKeyHandler(null);
-  }, [focusArea, focusIdx, qualities, showControls, showQuality, showRelated, ended, relatedVideos, onBack, onPlayNext, openControls, hideControlsLater, changeQuality]);
+  }, [focusArea, focusIdx, qualities, showControls, showQuality, showRelated, ended, relatedVideos, panelTab, upVideos, loadUpVideos, onBack, onPlayNext, openControls, hideControlsLater, changeQuality]);
 
   const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
 
@@ -468,6 +710,15 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
           display: 'flex', alignItems: 'center', justifyContent: 'center',
           background: 'rgba(0,0,0,0.8)', zIndex: 50 }}>
           <div className="loading"><div className="loading-spinner" />加载中...</div>
+        </div>
+      )}
+
+      {loadError && !loading && (
+        <div style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%',
+          display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
+          gap: 16, background: 'rgba(0,0,0,0.85)', zIndex: 50 }}>
+          <div style={{ fontSize: 26, color: '#fff' }}>视频加载失败</div>
+          <div style={{ fontSize: 18, color: '#aaa' }}>该视频源节点异常,请按返回键重试或换一个视频</div>
         </div>
       )}
 
@@ -494,28 +745,55 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
           <span className="player-time">{formatDuration(currentTime)} / {formatDuration(duration)}</span>
         </div>
 
-        {/* Related videos panel (4-column grid below controls) */}
-        {showRelated && relatedVideos.length > 0 && (
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 14, marginTop: 16, paddingBottom: 10 }}>
-            {relatedVideos.map((rv, i) => {
-              const thumb = (rv.pic || '').startsWith('//') ? 'https:' + rv.pic : rv.pic;
+        {/* Tabbed panel below controls: 相关推荐 / UP主投稿 */}
+        {showRelated && (
+          <div style={{ marginTop: 16, paddingBottom: 10 }}>
+            <div className="panel-tab-row" style={{ display: 'flex', gap: 14, marginBottom: 12 }}>
+              {[['related', '相关推荐'], ['up', upName ? `UP主投稿 · ${upName}` : 'UP主投稿']].map(([key, label]) => (
+                <div key={key} style={{
+                  padding: '6px 18px', fontSize: 18, borderRadius: 6,
+                  color: panelTab === key ? '#fff' : '#aaa',
+                  background: panelTab === key ? '#00a1d6' : 'rgba(255,255,255,0.08)',
+                  outline: focusArea === 'tabs' && panelTab === key ? '3px solid #fff' : 'none',
+                }}>{label}</div>
+              ))}
+            </div>
+
+            {(() => {
+              const list = panelTab === 'up' ? upVideos : relatedVideos;
+              if (list.length === 0) {
+                return <div style={{ color: '#888', fontSize: 18, padding: '20px 4px' }}>
+                  {panelTab === 'up' ? (upMidRef.current ? '加载中…' : '暂无 UP 主信息') : '暂无相关推荐'}
+                </div>;
+              }
               return (
-                <div key={rv.bvid || i} className="related-card" onClick={() => onPlayNext?.(rv)}
-                  style={{
-                    cursor: 'pointer',
-                    outline: focusArea === 'related' && focusIdx === i ? '4px solid #00a1d6' : 'none',
-                    borderRadius: 6, overflow: 'hidden',
-                  }}>
-                  <div style={{ width: '100%', aspectRatio: '16/9', background: '#1a1a2e', borderRadius: 6, overflow: 'hidden' }}>
-                    {thumb && <img src={thumb} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />}
-                  </div>
-                  <div style={{ padding: '6px 4px', fontSize: 18, color: '#ccc', lineHeight: 1.3,
-                    overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 1, WebkitBoxOrient: 'vertical' }}>
-                    {rv.title}
-                  </div>
+                <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 14 }}>
+                  {list.map((rv, i) => {
+                    const thumb = proxyImg(rv.pic);
+                    return (
+                      <div key={rv.bvid || i} className="related-card" onClick={() => onPlayNext?.(rv)}
+                        style={{
+                          cursor: 'pointer',
+                          outline: focusArea === 'related' && focusIdx === i ? '4px solid #00a1d6' : 'none',
+                          borderRadius: 6, overflow: 'hidden',
+                        }}>
+                        <div style={{ width: '100%', aspectRatio: '16/9', background: '#1a1a2e', borderRadius: 6, overflow: 'hidden' }}>
+                          {thumb && <img src={thumb} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />}
+                        </div>
+                        <div style={{ padding: '6px 4px 0', fontSize: 18, color: '#ccc', lineHeight: 1.3,
+                          overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 1, WebkitBoxOrient: 'vertical' }}>
+                          {rv.title}
+                        </div>
+                        <div style={{ padding: '2px 4px 6px', fontSize: 14, color: '#888',
+                          overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>
+                          {[rv.owner?.name, formatTime(rv.pubdate)].filter(Boolean).join(' · ')}
+                        </div>
+                      </div>
+                    );
+                  })}
                 </div>
               );
-            })}
+            })()}
           </div>
         )}
       </div>
@@ -538,28 +816,41 @@ export default function PlayerPage({ video, onBack, onPlayNext }) {
           background: 'rgba(0,0,0,0.85)', zIndex: 60,
           display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
         }}>
-          <div style={{ fontSize: 28, color: '#fff', marginBottom: 30 }}>播放结束</div>
-          <div style={{ fontSize: 20, color: '#aaa', marginBottom: 20 }}>接下来播放</div>
-          <div style={{ display: 'flex', gap: 20 }}>
-            {relatedVideos.map((rv, i) => {
-              const thumb = (rv.pic || '').startsWith('//') ? 'https:' + rv.pic : rv.pic;
+          <div style={{ fontSize: 30, color: '#fff', marginBottom: 6 }}>播放结束</div>
+          <div style={{ fontSize: 20, color: '#999', marginBottom: 28 }}>接下来播放</div>
+          <div style={{
+            display: 'grid', gridTemplateColumns: 'repeat(4, 300px)', gap: '24px 24px',
+            justifyContent: 'center',
+          }}>
+            {relatedVideos.slice(0, END_SCREEN_MAX).map((rv, i) => {
+              const thumb = proxyImg(rv.pic);
+              const focused = focusArea === 'endscreen' && focusIdx === i;
               return (
                 <div key={rv.bvid || i} onClick={() => onPlayNext?.(rv)}
                   style={{
-                    width: 280, cursor: 'pointer',
-                    outline: focusArea === 'endscreen' && focusIdx === i ? '4px solid #00a1d6' : 'none',
+                    width: 300, cursor: 'pointer',
+                    background: focused ? '#1f2440' : 'transparent',
+                    outline: focused ? '4px solid #00a1d6' : 'none',
                     borderRadius: 8, overflow: 'hidden',
+                    transition: 'background 0.15s',
                   }}>
-                  <div style={{ width: '100%', aspectRatio: '16/9', background: '#1a1a2e', borderRadius: 8, overflow: 'hidden' }}>
+                  <div style={{ width: '100%', aspectRatio: '16/9', background: '#1a1a2e', overflow: 'hidden' }}>
                     {thumb && <img src={thumb} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />}
                   </div>
-                  <div style={{ padding: '8px 4px', fontSize: 14, color: '#ccc', lineHeight: 1.3,
-                    overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}>
+                  <div style={{ padding: '8px 8px 2px', fontSize: 15, color: '#eee', lineHeight: 1.35,
+                    overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', height: 42 }}>
                     {rv.title}
+                  </div>
+                  <div style={{ padding: '0 8px 10px', fontSize: 13, color: '#888',
+                    overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>
+                    {[rv.owner?.name, formatTime(rv.pubdate)].filter(Boolean).join(' · ')}
                   </div>
                 </div>
               );
             })}
+          </div>
+          <div style={{ marginTop: 24, fontSize: 16, color: '#666' }}>
+            ← → ↑ ↓ 选择 · OK 播放 · 返回键 退出
           </div>
         </div>
       )}

--- a/app/src/utils/follow.js
+++ b/app/src/utils/follow.js
@@ -1,0 +1,32 @@
+// Cache of the logged-in user's followed UP mids, for the "已关注" card badge.
+// Web relation API caps at ~250 followings, so this is best-effort.
+import { getNavInfo, getFollowings } from '../api/client';
+
+let followedSet = null;
+let loadedAt = 0;
+const TTL = 30 * 60 * 1000; // 30 min
+
+export function getFollowedSet() {
+  return followedSet || new Set();
+}
+
+export async function loadFollowedMids(force) {
+  if (!force && followedSet && (Date.now() - loadedAt) < TTL) return followedSet;
+  const set = new Set();
+  try {
+    const nav = await getNavInfo();
+    const mid = nav?.data?.mid;
+    if (!mid) return followedSet || set;
+    for (let pn = 1; pn <= 5; pn++) {
+      const res = await getFollowings(mid, pn, 50);
+      const list = (res?.data?.list) || [];
+      list.forEach(u => { if (u.mid) set.add(u.mid); });
+      if (list.length < 50) break;
+    }
+    followedSet = set;
+    loadedAt = Date.now();
+  } catch (e) {
+    console.warn('[follow] loadFollowedMids failed:', e?.message || e);
+  }
+  return followedSet || set;
+}

--- a/package.json
+++ b/package.json
@@ -2,5 +2,8 @@
   "dependencies": {
     "ssh2": "^1.17.0",
     "ws": "^8.20.0"
+  },
+  "scripts": {
+    "test": "node --test service/com.biliwebos.app.service/test/*.test.js"
   }
 }

--- a/service/com.biliwebos.app.service/cast/castController.js
+++ b/service/com.biliwebos.app.service/cast/castController.js
@@ -1,0 +1,174 @@
+var EventEmitter = require('events');
+
+var PLAY_STATE_MAP = {
+  idle: 0,
+  loading: 3,
+  playing: 4,
+  paused: 5,
+  end: 6,
+  stop: 7,
+  error: 8,
+};
+
+function safeJsonParse(raw) {
+  if (!raw) return {};
+  try { return JSON.parse(raw); } catch (e) { return {}; }
+}
+
+function toNumber(value) {
+  var n = Number(value);
+  return isFinite(n) ? n : 0;
+}
+
+function normalizePlayPayload(payload) {
+  payload = payload || {};
+  var roomId = toNumber(payload.roomId || payload.room_id);
+  if (roomId > 0) {
+    return {
+      type: 'play',
+      contentType: 'live',
+      roomId: roomId,
+      title: payload.title || '',
+    };
+  }
+
+  var aid = toNumber(payload.aid);
+  var cid = toNumber(payload.cid);
+  var epid = toNumber(payload.epid || payload.epId);
+  var bvid = payload.bvid || '';
+  if (!aid && !cid && !epid && !bvid) return null;
+
+  return {
+    type: 'play',
+    contentType: 'video',
+    aid: aid || undefined,
+    cid: cid || undefined,
+    epid: epid || undefined,
+    bvid: bvid || undefined,
+    title: payload.title || '',
+  };
+}
+
+function parsePlayUrlPayload(payload) {
+  if (!payload || !payload.url) return null;
+  try {
+    var parsed = new URL(payload.url);
+    var ext = parsed.searchParams.get('nva_ext');
+    if (!ext) return null;
+    var decoded = safeJsonParse(decodeURIComponent(ext));
+    return normalizePlayPayload(decoded.content || decoded);
+  } catch (e) {
+    return null;
+  }
+}
+
+function CastController() {
+  this.sessions = new Map();
+  this.emitter = new EventEmitter();
+  this.status = {
+    sessionId: null,
+    deviceIp: null,
+    httpPort: null,
+    activeContent: null,
+    playState: 'idle',
+    progress: 0,
+    duration: 0,
+    lastCommandAt: 0,
+    lastError: null,
+  };
+}
+
+CastController.prototype.attachSession = function (session) {
+  this.sessions.set(session.id, session);
+  this.status.sessionId = session.id;
+};
+
+CastController.prototype.detachSession = function (sessionId) {
+  this.sessions.delete(sessionId);
+  if (this.status.sessionId === sessionId) this.status.sessionId = null;
+};
+
+CastController.prototype.onIntent = function (listener) {
+  this.emitter.on('intent', listener);
+  return this;
+};
+
+CastController.prototype.emitIntent = function (intent) {
+  this.emitter.emit('intent', intent);
+};
+
+CastController.prototype.handleCommand = function (sessionId, action, rawBody) {
+  var payload = safeJsonParse(rawBody);
+  var intent = null;
+
+  this.status.sessionId = sessionId;
+  this.status.lastCommandAt = Date.now();
+
+  if (action === 'Play') {
+    intent = normalizePlayPayload(payload);
+    if (intent) this.status.activeContent = intent;
+  } else if (action === 'PlayUrl') {
+    intent = parsePlayUrlPayload(payload);
+    if (intent) this.status.activeContent = intent;
+  } else if (action === 'Pause') {
+    intent = { type: 'pause' };
+  } else if (action === 'Resume') {
+    intent = { type: 'resume' };
+  } else if (action === 'Stop') {
+    intent = { type: 'stop' };
+    this.status.playState = 'stop';
+  } else if (action === 'Seek') {
+    intent = { type: 'seek', positionSec: toNumber(payload.seekTs || payload.position || payload.positionSec) };
+  } else if (action === 'SwitchDanmaku') {
+    intent = { type: 'switchDanmaku', open: !!payload.open };
+  }
+
+  if (intent) this.emitIntent(intent);
+  return intent;
+};
+
+CastController.prototype.reportState = function (payload) {
+  payload = payload || {};
+  this.status.playState = payload.playState || this.status.playState;
+  this.status.lastError = payload.error || null;
+
+  var numericState = PLAY_STATE_MAP[this.status.playState];
+  if (typeof numericState === 'number') {
+    this.sessions.forEach(function (session) {
+      session.sendCommand('OnPlayState', { playState: numericState });
+    });
+  }
+};
+
+CastController.prototype.reportProgress = function (payload) {
+  payload = payload || {};
+  this.status.duration = toNumber(payload.duration);
+  this.status.progress = toNumber(payload.position);
+
+  this.sessions.forEach(function (session) {
+    session.sendCommand('OnProgress', {
+      duration: payload.duration || 0,
+      position: payload.position || 0,
+    });
+  });
+};
+
+CastController.prototype.ack = function (payload) {
+  payload = payload || {};
+  this.status.lastAckAt = Date.now();
+  this.status.lastAck = payload;
+};
+
+CastController.prototype.setNetworkInfo = function (ip, httpPort) {
+  this.status.deviceIp = ip;
+  this.status.httpPort = httpPort;
+};
+
+CastController.prototype.getStatus = function () {
+  return JSON.parse(JSON.stringify(this.status));
+};
+
+module.exports = {
+  CastController: CastController,
+  PLAY_STATE_MAP: PLAY_STATE_MAP,
+};

--- a/service/com.biliwebos.app.service/cast/castController.js
+++ b/service/com.biliwebos.app.service/cast/castController.js
@@ -22,6 +22,7 @@ function toNumber(value) {
 
 function normalizePlayPayload(payload) {
   payload = payload || {};
+  var seekTs = toNumber(payload.seekTs || payload.seek_ts || payload.position || payload.positionSec);
   var roomId = toNumber(payload.roomId || payload.room_id);
   if (roomId > 0) {
     return {
@@ -29,6 +30,7 @@ function normalizePlayPayload(payload) {
       contentType: 'live',
       roomId: roomId,
       title: payload.title || '',
+      seekTs: seekTs,
     };
   }
 
@@ -46,6 +48,7 @@ function normalizePlayPayload(payload) {
     epid: epid || undefined,
     bvid: bvid || undefined,
     title: payload.title || '',
+    seekTs: seekTs,
   };
 }
 

--- a/service/com.biliwebos.app.service/cast/deviceProfile.js
+++ b/service/com.biliwebos.app.service/cast/deviceProfile.js
@@ -1,0 +1,160 @@
+var crypto = require('crypto');
+
+var SERVER_NAME = 'Linux/3.0.0, UPnP/1.0, Platinum/1.0.5.13';
+
+function xmlEscape(str) {
+  return String(str || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function formatHttpDate(date) {
+  return new Date(date || Date.now()).toUTCString();
+}
+
+function randomUuid() {
+  return crypto.randomBytes(18).toString('hex').toUpperCase().slice(0, 35);
+}
+
+function createDeviceProfile(options) {
+  options = options || {};
+  return {
+    uuid: options.uuid || randomUuid(),
+    ip: options.ip || '127.0.0.1',
+    httpPort: options.httpPort || 9958,
+    friendlyName: options.friendlyName || '我的小电视',
+    manufacturer: 'Bilibili Inc.',
+    manufacturerURL: 'https://www.bilibili.com/',
+    modelDescription: '云视听小电视',
+    modelName: 'BRAVIA 4K 2015',
+    modelNumber: '1024',
+    modelURL: 'https://app.bilibili.com/',
+    serialNumber: '1024',
+    brandName: 'ATV',
+    hostVersion: '25',
+    ottVersion: '105500',
+    channelName: 'master',
+    capability: '255',
+    serverName: SERVER_NAME,
+  };
+}
+
+function getLocation(profile) {
+  return 'http://' + profile.ip + ':' + profile.httpPort + '/description.xml';
+}
+
+function renderDescriptionXml(profile) {
+  return [
+    '<root xmlns:dlna="urn:schemas-dlna-org:device-1-0" xmlns="urn:schemas-upnp-org:device-1-0">',
+    '<specVersion><major>1</major><minor>0</minor></specVersion>',
+    '<device>',
+    '<deviceType>urn:schemas-upnp-org:device:MediaRenderer:1</deviceType>',
+    '<UDN>uuid:' + xmlEscape(profile.uuid) + '</UDN>',
+    '<friendlyName>' + xmlEscape(profile.friendlyName) + '</friendlyName>',
+    '<manufacturer>' + xmlEscape(profile.manufacturer) + '</manufacturer>',
+    '<manufacturerURL>' + xmlEscape(profile.manufacturerURL) + '</manufacturerURL>',
+    '<modelDescription>' + xmlEscape(profile.modelDescription) + '</modelDescription>',
+    '<modelName>' + xmlEscape(profile.modelName) + '</modelName>',
+    '<modelNumber>' + xmlEscape(profile.modelNumber) + '</modelNumber>',
+    '<modelURL>' + xmlEscape(profile.modelURL) + '</modelURL>',
+    '<serialNumber>' + xmlEscape(profile.serialNumber) + '</serialNumber>',
+    '<X_brandName>' + xmlEscape(profile.brandName) + '</X_brandName>',
+    '<hostVersion>' + xmlEscape(profile.hostVersion) + '</hostVersion>',
+    '<ottVersion>' + xmlEscape(profile.ottVersion) + '</ottVersion>',
+    '<channelName>' + xmlEscape(profile.channelName) + '</channelName>',
+    '<capability>' + xmlEscape(profile.capability) + '</capability>',
+    '<dlna:X_DLNADOC xmlns:dlna="urn:schemas-dlna-org:device-1-0">DMR-1.50</dlna:X_DLNADOC>',
+    '<dlna:X_DLNACAP xmlns:dlna="urn:schemas-dlna-org:device-1-0">playcontainer-1-0</dlna:X_DLNACAP>',
+    '<serviceList>',
+    '<service>',
+    '<serviceType>urn:schemas-upnp-org:service:AVTransport:1</serviceType>',
+    '<serviceId>urn:upnp-org:serviceId:AVTransport</serviceId>',
+    '<controlURL>AVTransport/action</controlURL>',
+    '<eventSubURL>AVTransport/event</eventSubURL>',
+    '<SCPDURL>dlna/AVTransport.xml</SCPDURL>',
+    '</service>',
+    '<service>',
+    '<serviceType>urn:app-bilibili-com:service:NirvanaControl:3</serviceType>',
+    '<serviceId>urn:app-bilibili-com:serviceId:NirvanaControl</serviceId>',
+    '<controlURL>NirvanaControl/action</controlURL>',
+    '<eventSubURL>NirvanaControl/event</eventSubURL>',
+    '<SCPDURL>dlna/NirvanaControl.xml</SCPDURL>',
+    '</service>',
+    '</serviceList>',
+    '</device>',
+    '</root>'
+  ].join('');
+}
+
+function renderAvTransportScpd() {
+  return [
+    '<?xml version="1.0"?>',
+    '<scpd xmlns="urn:schemas-upnp-org:service-1-0">',
+    '<specVersion><major>1</major><minor>0</minor></specVersion>',
+    '<actionList>',
+    '<action><name>Play</name></action>',
+    '<action><name>Pause</name></action>',
+    '<action><name>Stop</name></action>',
+    '<action><name>Seek</name></action>',
+    '</actionList>',
+    '</scpd>'
+  ].join('');
+}
+
+function renderNirvanaScpd() {
+  return '<actionList><action><name>GetAppInfo</name><argumentList></argumentList></action></actionList>';
+}
+
+function buildNotify(profile, nt, usn) {
+  return [
+    'NOTIFY * HTTP/1.1',
+    'HOST: 239.255.255.250:1900',
+    'LOCATION: ' + getLocation(profile),
+    'CACHE-CONTROL: max-age=30',
+    'SERVER: ' + profile.serverName,
+    'NTS: ssdp:alive',
+    'USN: ' + usn,
+    'NT: ' + nt,
+    '',
+    ''
+  ].join('\r\n');
+}
+
+function getSsdpNotifyPackets(profile) {
+  var uuid = 'uuid:' + profile.uuid;
+  return [
+    buildNotify(profile, 'upnp:rootdevice', uuid + '::upnp:rootdevice'),
+    buildNotify(profile, 'urn:schemas-upnp-org:device:MediaRenderer:1', uuid + '::urn:schemas-upnp-org:device:MediaRenderer:1'),
+    buildNotify(profile, 'urn:schemas-upnp-org:service:AVTransport:1', uuid + '::urn:schemas-upnp-org:service:AVTransport:1'),
+    buildNotify(profile, 'urn:app-bilibili-com:service:NirvanaControl:3', uuid + '::urn:app-bilibili-com:service:NirvanaControl:3')
+  ];
+}
+
+function getSsdpSearchResponse(profile, st) {
+  return [
+    'HTTP/1.1 200 OK',
+    'LOCATION: ' + getLocation(profile),
+    'CACHE-CONTROL: max-age=30',
+    'SERVER: ' + profile.serverName,
+    'EXT:',
+    'BOOTID.UPNP.ORG: 1669443520',
+    'CONFIGID.UPNP.ORG: 10177363',
+    'USN: uuid:atvbilibili&' + profile.uuid + '::upnp:rootdevice',
+    'ST: upnp:rootdevice',
+    'DATE: ' + formatHttpDate(),
+    '',
+    ''
+  ].join('\r\n');
+}
+
+module.exports = {
+  createDeviceProfile: createDeviceProfile,
+  renderDescriptionXml: renderDescriptionXml,
+  renderAvTransportScpd: renderAvTransportScpd,
+  renderNirvanaScpd: renderNirvanaScpd,
+  getSsdpNotifyPackets: getSsdpNotifyPackets,
+  getSsdpSearchResponse: getSsdpSearchResponse,
+  getLocation: getLocation,
+};

--- a/service/com.biliwebos.app.service/cast/deviceProfile.js
+++ b/service/com.biliwebos.app.service/cast/deviceProfile.js
@@ -135,12 +135,8 @@ function getSsdpNotifyPackets(profile) {
 function getSsdpSearchResponse(profile, st) {
   // Honor the ST the control point actually searched for so the response
   // matches its M-SEARCH (a hardcoded rootdevice ST made some controllers
-  // ignore the reply). BUT `ssdp:all` is a wildcard, not a concrete target —
-  // echoing it as the ST/USN is invalid and gets ignored (this is what broke
-  // discovery from the Bilibili app, which searches with ssdp:all). Answer
-  // wildcard/empty searches as the root device.
-  var requested = (st && String(st).trim()) || '';
-  var searchTarget = (!requested || requested === 'ssdp:all') ? 'upnp:rootdevice' : requested;
+  // ignore the reply). Fall back to rootdevice when no ST was supplied.
+  var searchTarget = (st && String(st).trim()) || 'upnp:rootdevice';
   // A uuid:<UDN>-style ST advertises the device itself; its USN is just the
   // UDN. For a rootdevice/service ST the USN is "<UDN>::<ST>".
   var usnSuffix = /^uuid:/i.test(searchTarget) ? '' : ('::' + searchTarget);

--- a/service/com.biliwebos.app.service/cast/deviceProfile.js
+++ b/service/com.biliwebos.app.service/cast/deviceProfile.js
@@ -135,8 +135,12 @@ function getSsdpNotifyPackets(profile) {
 function getSsdpSearchResponse(profile, st) {
   // Honor the ST the control point actually searched for so the response
   // matches its M-SEARCH (a hardcoded rootdevice ST made some controllers
-  // ignore the reply). Fall back to rootdevice when no ST was supplied.
-  var searchTarget = (st && String(st).trim()) || 'upnp:rootdevice';
+  // ignore the reply). BUT `ssdp:all` is a wildcard, not a concrete target —
+  // echoing it as the ST/USN is invalid and gets ignored (this is what broke
+  // discovery from the Bilibili app, which searches with ssdp:all). Answer
+  // wildcard/empty searches as the root device.
+  var requested = (st && String(st).trim()) || '';
+  var searchTarget = (!requested || requested === 'ssdp:all') ? 'upnp:rootdevice' : requested;
   // A uuid:<UDN>-style ST advertises the device itself; its USN is just the
   // UDN. For a rootdevice/service ST the USN is "<UDN>::<ST>".
   var usnSuffix = /^uuid:/i.test(searchTarget) ? '' : ('::' + searchTarget);

--- a/service/com.biliwebos.app.service/cast/nvaSession.js
+++ b/service/com.biliwebos.app.service/cast/nvaSession.js
@@ -1,0 +1,201 @@
+function readUInt32BE(buffer, offset) {
+  return buffer.readUInt32BE(offset);
+}
+
+function writeUInt32BE(value) {
+  var buf = Buffer.alloc(4);
+  buf.writeUInt32BE(value >>> 0, 0);
+  return buf;
+}
+
+function decodeFrame(buffer) {
+  var typeByte = buffer[0];
+  var paramCount = buffer[1];
+  var version = readUInt32BE(buffer, 2);
+  var frame = {
+    rawType: typeByte,
+    version: version,
+    paramCount: paramCount,
+    type: typeByte === 0xe0 ? 'command' : (typeByte === 0xc0 ? 'reply' : 'ping'),
+    command: '',
+    action: '',
+    body: '',
+  };
+
+  if (paramCount === 0) return frame;
+
+  var cursor = 6;
+  if (buffer.length > cursor) cursor += 1; // marker
+  var commandLength = buffer[cursor];
+  cursor += 1;
+  frame.command = buffer.subarray(cursor, cursor + commandLength).toString('utf8');
+  cursor += commandLength;
+
+  if (typeByte !== 0xe0 || paramCount === 1) return frame;
+
+  var actionLength = buffer[cursor];
+  cursor += 1;
+  frame.action = buffer.subarray(cursor, cursor + actionLength).toString('utf8');
+  cursor += actionLength;
+
+  if (paramCount === 3) {
+    var bodyLength = readUInt32BE(buffer, cursor);
+    cursor += 4;
+    frame.body = buffer.subarray(cursor, cursor + bodyLength).toString('utf8');
+  }
+
+  return frame;
+}
+
+function encodeEmptyReply(version) {
+  return Buffer.concat([
+    Buffer.from([0xc0, 0x00]),
+    writeUInt32BE(version)
+  ]);
+}
+
+function encodeJsonReply(version, content) {
+  var body = Buffer.from(JSON.stringify(content || {}));
+  return Buffer.concat([
+    Buffer.from([0xc0, 0x01]),
+    writeUInt32BE(version),
+    writeUInt32BE(body.length),
+    body
+  ]);
+}
+
+function encodeCommand(version, action, content) {
+  var command = Buffer.from('Command');
+  var actionBuf = Buffer.from(action || '');
+  var body = Buffer.from(JSON.stringify(content || {}));
+  return Buffer.concat([
+    Buffer.from([0xe0, 0x03]),
+    writeUInt32BE(version),
+    Buffer.from([0x01, command.length]),
+    command,
+    Buffer.from([actionBuf.length]),
+    actionBuf,
+    writeUInt32BE(body.length),
+    body
+  ]);
+}
+
+function encodePing(version) {
+  return Buffer.concat([
+    Buffer.from([0xe4, 0x00]),
+    writeUInt32BE(version)
+  ]);
+}
+
+function NvaSession(id, socket, onFrame, onClose) {
+  this.id = id;
+  this.socket = socket;
+  this.currentVersion = 1;
+  this.buffer = Buffer.alloc(0);
+  this.onFrame = onFrame;
+  this.onClose = onClose;
+  this.closed = false;
+  this.pingTimer = null;
+
+  var self = this;
+  socket.on('data', function (chunk) {
+    self.handleData(chunk);
+  });
+  socket.on('close', function () {
+    self.close();
+  });
+  socket.on('end', function () {
+    self.close();
+  });
+  socket.on('error', function () {
+    self.close();
+  });
+}
+
+NvaSession.prototype.startPing = function () {
+  var self = this;
+  if (self.pingTimer) clearInterval(self.pingTimer);
+  self.pingTimer = setInterval(function () {
+    if (!self.closed) self.sendPing();
+  }, 10000);
+};
+
+NvaSession.prototype.handleData = function (chunk) {
+  this.buffer = Buffer.concat([this.buffer, chunk]);
+  while (this.buffer.length >= 6) {
+    var typeByte = this.buffer[0];
+    var paramCount = this.buffer[1];
+    var total = 6;
+
+    if (paramCount === 0) {
+      total = 6;
+    } else if (typeByte === 0xc0) {
+      if (paramCount === 1) {
+        if (this.buffer.length < 10) return;
+        total = 10 + this.buffer.readUInt32BE(6);
+      } else {
+        total = 6;
+      }
+    } else {
+      if (this.buffer.length < 9) return;
+      var commandLength = this.buffer[7];
+      total = 8 + commandLength;
+      if (paramCount >= 2) {
+        if (this.buffer.length < total + 1) return;
+        var actionLength = this.buffer[total];
+        total += 1 + actionLength;
+      }
+      if (paramCount === 3) {
+        if (this.buffer.length < total + 4) return;
+        total += 4 + this.buffer.readUInt32BE(total);
+      }
+    }
+
+    if (this.buffer.length < total) return;
+    var frameBuffer = this.buffer.subarray(0, total);
+    this.buffer = this.buffer.subarray(total);
+    var frame = decodeFrame(frameBuffer);
+    this.currentVersion = Math.max(this.currentVersion, frame.version);
+    if (this.onFrame) this.onFrame(this, frame);
+  }
+};
+
+NvaSession.prototype.sendBuffer = function (buf) {
+  if (!this.closed) this.socket.write(buf);
+};
+
+NvaSession.prototype.sendEmpty = function () {
+  this.currentVersion += 1;
+  this.sendBuffer(encodeEmptyReply(this.currentVersion));
+};
+
+NvaSession.prototype.sendReply = function (content) {
+  this.currentVersion += 1;
+  this.sendBuffer(encodeJsonReply(this.currentVersion, content));
+};
+
+NvaSession.prototype.sendCommand = function (action, content) {
+  this.currentVersion += 1;
+  this.sendBuffer(encodeCommand(this.currentVersion, action, content));
+};
+
+NvaSession.prototype.sendPing = function () {
+  this.currentVersion += 1;
+  this.sendBuffer(encodePing(this.currentVersion));
+};
+
+NvaSession.prototype.close = function () {
+  if (this.closed) return;
+  this.closed = true;
+  if (this.pingTimer) clearInterval(this.pingTimer);
+  try { this.socket.destroy(); } catch (e) {}
+  if (this.onClose) this.onClose(this);
+};
+
+module.exports = {
+  decodeFrame: decodeFrame,
+  encodeEmptyReply: encodeEmptyReply,
+  encodeJsonReply: encodeJsonReply,
+  encodeCommand: encodeCommand,
+  NvaSession: NvaSession,
+};

--- a/service/com.biliwebos.app.service/cast/ssdpServer.js
+++ b/service/com.biliwebos.app.service/cast/ssdpServer.js
@@ -1,0 +1,192 @@
+var dgram = require('dgram');
+var net = require('net');
+
+var deviceProfile = require('./deviceProfile');
+var nvaSession = require('./nvaSession');
+
+function parseHeaders(raw) {
+  var lines = raw.split('\r\n');
+  var requestLine = lines.shift() || '';
+  var parts = requestLine.split(' ');
+  var headers = {};
+  lines.forEach(function (line) {
+    if (!line) return;
+    var idx = line.indexOf(':');
+    if (idx <= 0) return;
+    headers[line.slice(0, idx).trim().toLowerCase()] = line.slice(idx + 1).trim();
+  });
+  return {
+    method: parts[0] || '',
+    path: parts[1] || '/',
+    version: parts[2] || 'HTTP/1.1',
+    headers: headers,
+  };
+}
+
+function httpResponse(statusCode, statusText, headers, body) {
+  var lines = ['HTTP/1.1 ' + statusCode + ' ' + statusText];
+  Object.keys(headers || {}).forEach(function (key) {
+    lines.push(key + ': ' + headers[key]);
+  });
+  lines.push('', body || '');
+  return lines.join('\r\n');
+}
+
+function CastLanServer(options) {
+  options = options || {};
+  this.profile = options.profile;
+  this.controller = options.controller;
+  this.onFrame = options.onFrame;
+  this.tcpPort = this.profile.httpPort;
+  this.udpServer = null;
+  this.tcpServer = null;
+  this.broadcastTimer = null;
+  this.nextSessionId = 1;
+}
+
+CastLanServer.prototype.start = function (callback) {
+  var self = this;
+  self.startUdp();
+  self.startTcp(function () {
+    self.broadcastAlive();
+    self.broadcastTimer = setInterval(function () {
+      self.broadcastAlive();
+    }, 1000);
+    if (callback) callback();
+  });
+};
+
+CastLanServer.prototype.startUdp = function () {
+  var self = this;
+  self.udpServer = dgram.createSocket({ type: 'udp4', reuseAddr: true });
+  self.udpServer.on('message', function (msg, rinfo) {
+    var str = msg.toString('utf8');
+    if (str.toLowerCase().indexOf('ssdp:discover') < 0) return;
+    var st = 'urn:schemas-upnp-org:device:MediaRenderer:1';
+    var match = str.match(/\r\nST:\s*(.+)\r\n/i);
+    if (match) st = match[1].trim();
+    var response = deviceProfile.getSsdpSearchResponse(self.profile, st);
+    self.udpServer.send(Buffer.from(response), rinfo.port, rinfo.address);
+  });
+  self.udpServer.on('error', function (err) {
+    console.error('[Cast][SSDP] error:', err.message);
+  });
+  self.udpServer.bind(1900, function () {
+    try { self.udpServer.addMembership('239.255.255.250'); } catch (e) {}
+    try { self.udpServer.setBroadcast(true); } catch (e) {}
+    try { self.udpServer.setMulticastTTL(2); } catch (e) {}
+  });
+};
+
+CastLanServer.prototype.startTcp = function (callback) {
+  var self = this;
+  self.tcpServer = net.createServer(function (socket) {
+    self.handleSocket(socket);
+  });
+  self.tcpServer.on('error', function (err) {
+    console.error('[Cast][TCP] error:', err.message);
+    if (err.code === 'EADDRINUSE') {
+      self.tcpPort += 1;
+      self.profile.httpPort = self.tcpPort;
+      self.startTcp(callback);
+    }
+  });
+  self.tcpServer.listen(self.tcpPort, '0.0.0.0', callback);
+};
+
+CastLanServer.prototype.handleSocket = function (socket) {
+  var self = this;
+  var headerBuffer = '';
+  var handled = false;
+
+  function onData(chunk) {
+    if (handled) return;
+    headerBuffer += chunk.toString('utf8');
+    var idx = headerBuffer.indexOf('\r\n\r\n');
+    if (idx < 0) return;
+    handled = true;
+
+    var raw = headerBuffer.slice(0, idx);
+    var request = parseHeaders(raw);
+    socket.removeListener('data', onData);
+    self.routeRequest(socket, request);
+  }
+
+  socket.on('data', onData);
+};
+
+CastLanServer.prototype.routeRequest = function (socket, request) {
+  var path = request.path || '/';
+  if (request.method === 'SETUP' && path === '/projection') {
+    var session = new nvaSession.NvaSession(
+      'session-' + (this.nextSessionId++),
+      socket,
+      this.onFrame,
+      this.handleSessionClose.bind(this)
+    );
+    this.controller.attachSession(session);
+    session.startPing();
+    socket.write([
+      'NVA/1.0 200 OK',
+      'Session: ' + (request.headers.session || session.id),
+      'NvaVersion: 1',
+      'Connection: Keep-Alive',
+      'UUID: ' + this.profile.uuid,
+      'User-Agent: ' + this.profile.serverName.replace(',', ''),
+      '',
+      ''
+    ].join('\r\n'));
+    return;
+  }
+
+  var body = '';
+  var status = 200;
+  var statusText = 'OK';
+  var headers = { 'Content-Type': 'text/plain; charset=utf-8', 'Connection': 'close' };
+
+  if (request.method === 'GET' && path === '/description.xml') {
+    body = deviceProfile.renderDescriptionXml(this.profile);
+    headers['Content-Type'] = 'text/xml; charset=utf-8';
+  } else if (request.method === 'GET' && path === '/dlna/AVTransport.xml') {
+    body = deviceProfile.renderAvTransportScpd();
+    headers['Content-Type'] = 'text/xml; charset=utf-8';
+  } else if (request.method === 'GET' && path === '/dlna/NirvanaControl.xml') {
+    body = deviceProfile.renderNirvanaScpd();
+    headers['Content-Type'] = 'text/xml; charset=utf-8';
+  } else if (request.method === 'POST' && (path === '/AVTransport/action' || path === '/NirvanaControl/action')) {
+    body = '';
+  } else {
+    status = 404;
+    statusText = 'Not Found';
+    body = 'Not Found';
+  }
+
+  headers['Content-Length'] = Buffer.byteLength(body);
+  socket.end(httpResponse(status, statusText, headers, body));
+};
+
+CastLanServer.prototype.handleSessionClose = function (session) {
+  this.controller.detachSession(session.id);
+};
+
+CastLanServer.prototype.broadcastAlive = function () {
+  var self = this;
+  if (!self.udpServer) return;
+  deviceProfile.getSsdpNotifyPackets(self.profile).forEach(function (packet) {
+    self.udpServer.send(Buffer.from(packet), 1900, '239.255.255.250');
+  });
+};
+
+CastLanServer.prototype.stop = function () {
+  if (this.broadcastTimer) clearInterval(this.broadcastTimer);
+  if (this.udpServer) {
+    try { this.udpServer.close(); } catch (e) {}
+  }
+  if (this.tcpServer) {
+    try { this.tcpServer.close(); } catch (e) {}
+  }
+};
+
+module.exports = {
+  CastLanServer: CastLanServer,
+};

--- a/service/com.biliwebos.app.service/service.js
+++ b/service/com.biliwebos.app.service/service.js
@@ -9,7 +9,12 @@ var http = require('http');
 var zlib = require('zlib');
 var fs = require('fs');
 var path = require('path');
-var url = require('url');
+var os = require('os');
+var childProcess = require('child_process');
+
+var deviceProfile = require('./cast/deviceProfile');
+var CastController = require('./cast/castController').CastController;
+var CastLanServer = require('./cast/ssdpServer').CastLanServer;
 
 var service = new Service('com.biliwebos.app.service');
 
@@ -24,6 +29,22 @@ try {
 
 function saveCookies() {
   try { fs.writeFileSync(COOKIE_FILE, JSON.stringify(storedCookies)); } catch (e) { }
+}
+
+var CAST_CONFIG_FILE = path.join('/media/internal', 'bili_cast_config.json');
+var castConfig = {};
+try {
+  if (fs.existsSync(CAST_CONFIG_FILE)) {
+    castConfig = JSON.parse(fs.readFileSync(CAST_CONFIG_FILE, 'utf-8'));
+  }
+} catch (e) { }
+
+if (castConfig.friendlyName === 'B站 webOS') {
+  castConfig.friendlyName = '我的小电视';
+}
+
+function saveCastConfig() {
+  try { fs.writeFileSync(CAST_CONFIG_FILE, JSON.stringify(castConfig)); } catch (e) { }
 }
 
 function serializeCookies(cookies) {
@@ -109,6 +130,95 @@ function decompressResponse(res, callback) {
   });
 }
 
+function getLanIp() {
+  var nets = os.networkInterfaces();
+  var names = Object.keys(nets);
+  for (var i = 0; i < names.length; i++) {
+    var rows = nets[names[i]] || [];
+    for (var j = 0; j < rows.length; j++) {
+      var row = rows[j];
+      if (row && row.family === 'IPv4' && !row.internal) return row.address;
+    }
+  }
+  return '127.0.0.1';
+}
+
+function getCastFriendlyName() {
+  return castConfig.friendlyName || '我的小电视';
+}
+
+var castController = new CastController();
+var castSubscribers = [];
+var pendingCastEvent = null;
+var castProfile = deviceProfile.createDeviceProfile({
+  uuid: castConfig.uuid,
+  friendlyName: getCastFriendlyName(),
+  ip: getLanIp(),
+  httpPort: 9958,
+});
+
+castConfig.uuid = castProfile.uuid;
+saveCastConfig();
+
+function notifyCastSubscribers(event) {
+  pendingCastEvent = event;
+  castSubscribers = castSubscribers.filter(function (message) {
+    try {
+      message.respond({
+        returnValue: true,
+        subscribed: true,
+        event: event,
+        status: castController.getStatus(),
+      });
+      pendingCastEvent = null;
+      return true;
+    } catch (e) {
+      return false;
+    }
+  });
+}
+
+function launchAppForCast() {
+  childProcess.execFile('luna-send-pub', [
+    '-n', '1', '-f',
+    'luna://com.webos.service.applicationmanager/launch',
+    '{"id":"com.biliwebos.app"}'
+  ], function (err, stdout, stderr) {
+    if (err) {
+      console.error('[Cast] launch app failed:', err.message);
+      return;
+    }
+    if (stderr) console.log('[Cast] launch stderr:', stderr.trim());
+    if (stdout) console.log('[Cast] launch:', stdout.trim());
+  });
+}
+
+castController.onIntent(function (intent) {
+  launchAppForCast();
+  notifyCastSubscribers({ kind: 'command', command: intent });
+});
+
+var castLanServer = new CastLanServer({
+  profile: castProfile,
+  controller: castController,
+  onFrame: function (session, frame) {
+    if (frame.action === 'GetVolume') {
+      session.sendReply({ volume: 30 });
+      return;
+    }
+    if (frame.type !== 'command') return;
+
+    var intent = castController.handleCommand(session.id, frame.action, frame.body);
+    if (frame.action === 'PlayUrl' && !intent) {
+      session.sendReply({ accepted: false, reason: 'unsupported-playurl' });
+      return;
+    }
+    session.sendEmpty();
+  },
+});
+
+castController.setNetworkInfo(castProfile.ip, castProfile.httpPort);
+
 // ==================== Luna Bus Methods ====================
 
 service.register('fetch', function (message) {
@@ -167,8 +277,57 @@ service.register('ping', function (message) {
     returnValue: true, status: 'ok',
     cookieKeys: Object.keys(storedCookies),
     nodeVersion: process.version,
-    localProxyPort: LOCAL_PROXY_PORT
+    localProxyPort: LOCAL_PROXY_PORT,
+    castHttpPort: castProfile.httpPort,
+    castFriendlyName: getCastFriendlyName(),
   });
+});
+
+service.register('castSubscribe', function (message) {
+  if (message.isSubscription || message.payload.subscribe) {
+    castSubscribers.push(message);
+    message.respond({
+      returnValue: true,
+      subscribed: true,
+      event: pendingCastEvent || { kind: 'ready' },
+      status: castController.getStatus(),
+    });
+    if (pendingCastEvent && pendingCastEvent.kind === 'command') pendingCastEvent = null;
+    return;
+  }
+  message.respond({
+    returnValue: true,
+    subscribed: false,
+    status: castController.getStatus(),
+  });
+});
+
+service.register('castAck', function (message) {
+  castController.ack(message.payload || {});
+  message.respond({ returnValue: true, status: castController.getStatus() });
+});
+
+service.register('castReportState', function (message) {
+  castController.reportState(message.payload || {});
+  notifyCastSubscribers({ kind: 'state', payload: message.payload || {} });
+  message.respond({ returnValue: true });
+});
+
+service.register('castReportProgress', function (message) {
+  castController.reportProgress(message.payload || {});
+  message.respond({ returnValue: true });
+});
+
+service.register('castGetStatus', function (message) {
+  message.respond({ returnValue: true, status: castController.getStatus() });
+});
+
+service.register('castSetConfig', function (message) {
+  if (message.payload && message.payload.friendlyName) {
+    castConfig.friendlyName = String(message.payload.friendlyName).slice(0, 64);
+    saveCastConfig();
+  }
+  message.respond({ returnValue: true, config: castConfig });
 });
 
 // ==================== Local HTTP Proxy ====================
@@ -239,6 +398,12 @@ localServer.on('error', function (err) {
 
 localServer.listen(LOCAL_PROXY_PORT, '127.0.0.1', function () {
   console.log('[BiliService] Local proxy on port ' + LOCAL_PROXY_PORT);
+});
+
+castLanServer.start(function () {
+  castProfile.ip = getLanIp();
+  castController.setNetworkInfo(castProfile.ip, castProfile.httpPort);
+  console.log('[BiliService] Cast server on ' + castProfile.ip + ':' + castProfile.httpPort);
 });
 
 // Keep service alive

--- a/service/com.biliwebos.app.service/service.js
+++ b/service/com.biliwebos.app.service/service.js
@@ -159,8 +159,22 @@ function getLanIp() {
   return '127.0.0.1';
 }
 
+// Derive a friendly default name from the LG model string, e.g.
+// "OLED65C4PCA.ACNQLJD" -> "LG 65C4" (matches the name LG's own DLNA uses).
+function friendlyModel(modelName) {
+  if (!modelName) return '';
+  var head = String(modelName).split('.')[0];
+  var m = head.match(/([0-9]{2,3}[A-Z][0-9]+)/); // 65C4 / 77G4 / 55B4 ...
+  return 'LG ' + (m ? m[1] : head);
+}
+
+// Default cast name = "哔哩哔哩 on <model>", resolved at runtime from this TV's
+// model (not hardcoded), so it's correct on any LG set. A name the user set
+// explicitly (castConfig.userSet) always wins.
+var computedDefaultName = null;
 function getCastFriendlyName() {
-  return castConfig.friendlyName || '我的小电视';
+  if (castConfig.userSet && castConfig.friendlyName) return castConfig.friendlyName;
+  return computedDefaultName || '我的小电视';
 }
 
 var castController = new CastController();
@@ -234,6 +248,20 @@ var castLanServer = new CastLanServer({
 });
 
 castController.setNetworkInfo(castProfile.ip, castProfile.httpPort);
+
+// Resolve the TV model and build the dynamic default name. Updating the shared
+// profile + re-advertising makes it live without a restart. Skipped if the user
+// set a custom name.
+service.call('luna://com.webos.service.tv.systemproperty/getSystemInfo',
+  { keys: ['modelName'] }, function (m) {
+    var modelName = m && m.payload && m.payload.modelName;
+    if (!modelName) return;
+    computedDefaultName = '哔哩哔哩 on ' + friendlyModel(modelName);
+    if (!(castConfig.userSet && castConfig.friendlyName)) {
+      castProfile.friendlyName = computedDefaultName;
+      try { castLanServer.broadcastAlive(); } catch (e) { }
+    }
+  });
 
 // ==================== Luna Bus Methods ====================
 
@@ -339,10 +367,19 @@ service.register('castGetStatus', function (message) {
 });
 
 service.register('castSetConfig', function (message) {
-  if (message.payload && message.payload.friendlyName) {
-    var name = String(message.payload.friendlyName).slice(0, 64).trim();
+  var payload = message.payload || {};
+  // reset:true (or an empty friendlyName) reverts to the dynamic model-based default.
+  if (payload.reset || payload.friendlyName === '') {
+    castConfig.userSet = false;
+    delete castConfig.friendlyName;
+    castProfile.friendlyName = computedDefaultName || '我的小电视';
+    saveCastConfig();
+    try { castLanServer.broadcastAlive(); } catch (e) { }
+  } else if (payload.friendlyName) {
+    var name = String(payload.friendlyName).slice(0, 64).trim();
     if (name) {
       castConfig.friendlyName = name;
+      castConfig.userSet = true;
       saveCastConfig();
       // Apply live: the LAN server reads profile.friendlyName at request time,
       // so updating the shared profile + re-advertising makes the new name show
@@ -351,7 +388,7 @@ service.register('castSetConfig', function (message) {
       try { castLanServer.broadcastAlive(); } catch (e) { }
     }
   }
-  message.respond({ returnValue: true, config: castConfig });
+  message.respond({ returnValue: true, config: castConfig, defaultName: computedDefaultName });
 });
 
 // ==================== Local HTTP Proxy ====================

--- a/service/com.biliwebos.app.service/service.js
+++ b/service/com.biliwebos.app.service/service.js
@@ -13,6 +13,10 @@ var url = require('url');
 
 var service = new Service('com.biliwebos.app.service');
 
+// Reuse TLS connections to CDN hosts. The TV's CPU makes a fresh TLS handshake
+// per segment expensive; keep-alive cuts initial-load and seek latency a lot.
+var keepAliveAgent = new https.Agent({ keepAlive: true, maxSockets: 8, keepAliveMsecs: 15000 });
+
 // Cookie storage
 var COOKIE_FILE = path.join('/media/internal', 'bili_cookies.json');
 var storedCookies = {};
@@ -44,7 +48,11 @@ function isAllowedHost(host) {
 }
 
 // Make HTTPS request helper
-function makeRequest(parsedUrl, method, body, contentType, range, callback) {
+// forceIdentity: never request gzip/deflate. Required for the binary proxy
+// path (segments/images) which pipes bytes raw without forwarding
+// Content-Encoding — compressed bytes there corrupt the Range/Content-Length
+// and trigger Shaka's "Payload length does not match range requested bytes".
+function makeRequest(parsedUrl, method, body, contentType, range, forceIdentity, callback) {
   var hostname = parsedUrl.hostname;
   var port = parsedUrl.port ? parseInt(parsedUrl.port) : 443;
   var isCDN = hostname.indexOf('bilivideo') >= 0 || hostname.indexOf('akamaized') >= 0;
@@ -54,7 +62,7 @@ function makeRequest(parsedUrl, method, body, contentType, range, callback) {
     'Referer': 'https://www.bilibili.com/',
     'Accept': isCDN ? '*/*' : 'application/json, text/plain, */*',
     'Accept-Language': 'zh-CN,zh;q=0.9',
-    'Accept-Encoding': isCDN ? 'identity' : 'gzip, deflate',
+    'Accept-Encoding': (isCDN || forceIdentity) ? 'identity' : 'gzip, deflate',
     'Cookie': serializeCookies(storedCookies)
   };
   if (!isCDN) headers['Origin'] = 'https://www.bilibili.com';
@@ -66,10 +74,14 @@ function makeRequest(parsedUrl, method, body, contentType, range, callback) {
     path: parsedUrl.pathname + (parsedUrl.search || ''),
     method: method || 'GET',
     headers: headers,
-    rejectUnauthorized: false
+    rejectUnauthorized: false,
+    agent: keepAliveAgent
   };
 
+  var done = false;
   var req = https.request(options, function (res) {
+    if (done) return;
+    done = true;
     var setCookieHeaders = res.headers['set-cookie'];
     if (setCookieHeaders) {
       setCookieHeaders.forEach(function (sc) {
@@ -84,7 +96,11 @@ function makeRequest(parsedUrl, method, body, contentType, range, callback) {
     callback(null, res);
   });
 
-  req.on('error', function (err) { callback(err); });
+  // Without a timeout a stuck CDN socket hangs forever and the segment never
+  // returns, freezing playback permanently. Bail out so the caller can fail
+  // the request and Shaka can retry.
+  req.setTimeout(10000, function () { req.destroy(new Error('Upstream timeout')); });
+  req.on('error', function (err) { if (done) return; done = true; callback(err); });
   if (body) req.write(body);
   req.end();
 }
@@ -124,7 +140,7 @@ service.register('fetch', function (message) {
   }
 
   makeRequest(parsed, message.payload.method, message.payload.body,
-    message.payload.contentType, message.payload.range, function (err, res) {
+    message.payload.contentType, message.payload.range, false, function (err, res) {
       if (err) { message.respond({ returnValue: false, error: err.message }); return; }
 
       decompressResponse(res, function (data) {
@@ -208,10 +224,9 @@ var localServer = http.createServer(function (req, res) {
     return;
   }
 
-  makeRequest(parsed, req.method, null, null, req.headers['range'], function (err, proxyRes) {
+  makeRequest(parsed, req.method, null, null, req.headers['range'], true, function (err, proxyRes) {
     if (err) {
-      res.writeHead(502);
-      res.end(err.message);
+      if (!res.headersSent) { res.writeHead(502); res.end(err.message); }
       return;
     }
 
@@ -225,6 +240,12 @@ var localServer = http.createServer(function (req, res) {
 
     res.writeHead(proxyRes.statusCode, responseHeaders);
     proxyRes.pipe(res);
+
+    // If the upstream errors/truncates mid-stream, tear down the client
+    // response (a half-delivered segment is what Shaka chokes on); if the
+    // client disconnects, free the upstream socket.
+    proxyRes.on('error', function () { res.destroy(); });
+    res.on('close', function () { proxyRes.destroy(); });
   });
 });
 

--- a/service/com.biliwebos.app.service/service.js
+++ b/service/com.biliwebos.app.service/service.js
@@ -340,8 +340,16 @@ service.register('castGetStatus', function (message) {
 
 service.register('castSetConfig', function (message) {
   if (message.payload && message.payload.friendlyName) {
-    castConfig.friendlyName = String(message.payload.friendlyName).slice(0, 64);
-    saveCastConfig();
+    var name = String(message.payload.friendlyName).slice(0, 64).trim();
+    if (name) {
+      castConfig.friendlyName = name;
+      saveCastConfig();
+      // Apply live: the LAN server reads profile.friendlyName at request time,
+      // so updating the shared profile + re-advertising makes the new name show
+      // up in the phone's cast list without a service restart.
+      castProfile.friendlyName = name;
+      try { castLanServer.broadcastAlive(); } catch (e) { }
+    }
   }
   message.respond({ returnValue: true, config: castConfig });
 });

--- a/service/com.biliwebos.app.service/service.js
+++ b/service/com.biliwebos.app.service/service.js
@@ -159,22 +159,8 @@ function getLanIp() {
   return '127.0.0.1';
 }
 
-// Derive a friendly default name from the LG model string, e.g.
-// "OLED65C4PCA.ACNQLJD" -> "LG 65C4" (matches the name LG's own DLNA uses).
-function friendlyModel(modelName) {
-  if (!modelName) return '';
-  var head = String(modelName).split('.')[0];
-  var m = head.match(/([0-9]{2,3}[A-Z][0-9]+)/); // 65C4 / 77G4 / 55B4 ...
-  return 'LG ' + (m ? m[1] : head);
-}
-
-// Default cast name = "哔哩哔哩 on <model>", resolved at runtime from this TV's
-// model (not hardcoded), so it's correct on any LG set. A name the user set
-// explicitly (castConfig.userSet) always wins.
-var computedDefaultName = null;
 function getCastFriendlyName() {
-  if (castConfig.userSet && castConfig.friendlyName) return castConfig.friendlyName;
-  return computedDefaultName || '我的小电视';
+  return castConfig.friendlyName || '我的小电视';
 }
 
 var castController = new CastController();
@@ -248,20 +234,6 @@ var castLanServer = new CastLanServer({
 });
 
 castController.setNetworkInfo(castProfile.ip, castProfile.httpPort);
-
-// Resolve the TV model and build the dynamic default name. Updating the shared
-// profile + re-advertising makes it live without a restart. Skipped if the user
-// set a custom name.
-service.call('luna://com.webos.service.tv.systemproperty/getSystemInfo',
-  { keys: ['modelName'] }, function (m) {
-    var modelName = m && m.payload && m.payload.modelName;
-    if (!modelName) return;
-    computedDefaultName = '哔哩哔哩 on ' + friendlyModel(modelName);
-    if (!(castConfig.userSet && castConfig.friendlyName)) {
-      castProfile.friendlyName = computedDefaultName;
-      try { castLanServer.broadcastAlive(); } catch (e) { }
-    }
-  });
 
 // ==================== Luna Bus Methods ====================
 
@@ -367,28 +339,11 @@ service.register('castGetStatus', function (message) {
 });
 
 service.register('castSetConfig', function (message) {
-  var payload = message.payload || {};
-  // reset:true (or an empty friendlyName) reverts to the dynamic model-based default.
-  if (payload.reset || payload.friendlyName === '') {
-    castConfig.userSet = false;
-    delete castConfig.friendlyName;
-    castProfile.friendlyName = computedDefaultName || '我的小电视';
+  if (message.payload && message.payload.friendlyName) {
+    castConfig.friendlyName = String(message.payload.friendlyName).slice(0, 64);
     saveCastConfig();
-    try { castLanServer.broadcastAlive(); } catch (e) { }
-  } else if (payload.friendlyName) {
-    var name = String(payload.friendlyName).slice(0, 64).trim();
-    if (name) {
-      castConfig.friendlyName = name;
-      castConfig.userSet = true;
-      saveCastConfig();
-      // Apply live: the LAN server reads profile.friendlyName at request time,
-      // so updating the shared profile + re-advertising makes the new name show
-      // up in the phone's cast list without a service restart.
-      castProfile.friendlyName = name;
-      try { castLanServer.broadcastAlive(); } catch (e) { }
-    }
   }
-  message.respond({ returnValue: true, config: castConfig, defaultName: computedDefaultName });
+  message.respond({ returnValue: true, config: castConfig });
 });
 
 // ==================== Local HTTP Proxy ====================

--- a/service/com.biliwebos.app.service/test/cast-controller.test.js
+++ b/service/com.biliwebos.app.service/test/cast-controller.test.js
@@ -1,0 +1,94 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { CastController } = require('../cast/castController');
+
+test('parse play command into video intent', () => {
+  const controller = new CastController();
+
+  const intent = controller.handleCommand('session-1', 'Play', JSON.stringify({
+    aid: 123,
+    bvid: 'BV1xx411c7mD',
+    cid: 456,
+    title: 'test video',
+  }));
+
+  assert.equal(intent.type, 'play');
+  assert.equal(intent.contentType, 'video');
+  assert.equal(intent.aid, 123);
+  assert.equal(intent.bvid, 'BV1xx411c7mD');
+  assert.equal(intent.cid, 456);
+  assert.equal(intent.title, 'test video');
+});
+
+test('parse play command into live intent', () => {
+  const controller = new CastController();
+
+  const intent = controller.handleCommand('session-1', 'Play', JSON.stringify({
+    roomId: 987654,
+    title: 'live room',
+  }));
+
+  assert.equal(intent.type, 'play');
+  assert.equal(intent.contentType, 'live');
+  assert.equal(intent.roomId, 987654);
+});
+
+test('parse playurl command via nva_ext payload into video intent', () => {
+  const controller = new CastController();
+  const ext = encodeURIComponent(JSON.stringify({
+    content: {
+      aid: 22,
+      cid: 33,
+      bvid: 'BV1ab411c7mD',
+      title: 'from playurl',
+    },
+  }));
+
+  const intent = controller.handleCommand('session-1', 'PlayUrl', JSON.stringify({
+    url: `https://example.com/play?foo=bar&nva_ext=${ext}`,
+  }));
+
+  assert.equal(intent.type, 'play');
+  assert.equal(intent.contentType, 'video');
+  assert.equal(intent.aid, 22);
+  assert.equal(intent.cid, 33);
+  assert.equal(intent.bvid, 'BV1ab411c7mD');
+});
+
+test('unsupported playurl payload is ignored without clobbering active session', () => {
+  const controller = new CastController();
+
+  controller.handleCommand('session-1', 'Play', JSON.stringify({ aid: 1, cid: 2, bvid: 'BV1' }));
+  const before = controller.getStatus();
+  const result = controller.handleCommand('session-1', 'PlayUrl', JSON.stringify({
+    url: 'https://example.com/play?foo=bar',
+  }));
+  const after = controller.getStatus();
+
+  assert.equal(result, null);
+  assert.deepEqual(after.activeContent, before.activeContent);
+});
+
+test('reporting state and progress produces outbound NVA events', () => {
+  const controller = new CastController();
+  const sent = [];
+
+  controller.attachSession({
+    id: 'session-1',
+    sendCommand(action, content) {
+      sent.push({ action, content });
+    },
+    sendReply() {},
+    sendEmpty() {},
+  });
+
+  controller.handleCommand('session-1', 'Play', JSON.stringify({ aid: 1, cid: 2, bvid: 'BV1' }));
+  controller.reportState({ playState: 'playing' });
+  controller.reportProgress({ duration: 100, position: 45 });
+
+  assert.deepEqual(sent, [
+    { action: 'OnPlayState', content: { playState: 4 } },
+    { action: 'OnProgress', content: { duration: 100, position: 45 } },
+  ]);
+});

--- a/service/com.biliwebos.app.service/test/cast-controller.test.js
+++ b/service/com.biliwebos.app.service/test/cast-controller.test.js
@@ -11,6 +11,7 @@ test('parse play command into video intent', () => {
     bvid: 'BV1xx411c7mD',
     cid: 456,
     title: 'test video',
+    seekTs: 123.4,
   }));
 
   assert.equal(intent.type, 'play');
@@ -19,6 +20,7 @@ test('parse play command into video intent', () => {
   assert.equal(intent.bvid, 'BV1xx411c7mD');
   assert.equal(intent.cid, 456);
   assert.equal(intent.title, 'test video');
+  assert.equal(intent.seekTs, 123.4);
 });
 
 test('parse play command into live intent', () => {
@@ -91,4 +93,11 @@ test('reporting state and progress produces outbound NVA events', () => {
     { action: 'OnPlayState', content: { playState: 4 } },
     { action: 'OnProgress', content: { duration: 100, position: 45 } },
   ]);
+});
+
+
+test('parse seek command with seekTs field', () => {
+  const controller = new CastController();
+  const intent = controller.handleCommand('session-1', 'Seek', JSON.stringify({ seekTs: 88 }));
+  assert.deepEqual(intent, { type: 'seek', positionSec: 88 });
 });

--- a/service/com.biliwebos.app.service/test/device-profile.test.js
+++ b/service/com.biliwebos.app.service/test/device-profile.test.js
@@ -1,0 +1,50 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createDeviceProfile,
+  renderDescriptionXml,
+  getSsdpNotifyPackets,
+  getSsdpSearchResponse,
+} = require('../cast/deviceProfile');
+
+test('description xml exposes AVTransport and NirvanaControl services', () => {
+  const profile = createDeviceProfile({ ip: '192.168.1.2', httpPort: 9958, friendlyName: 'B站 webOS' });
+  const xml = renderDescriptionXml(profile);
+
+  assert.match(xml, /<friendlyName>B站 webOS<\/friendlyName>/);
+  assert.match(xml, /urn:schemas-upnp-org:service:AVTransport:1/);
+  assert.match(xml, /urn:app-bilibili-com:service:NirvanaControl:3/);
+  assert.match(xml, /<controlURL>AVTransport\/action<\/controlURL>/);
+  assert.match(xml, /<controlURL>NirvanaControl\/action<\/controlURL>/);
+});
+
+test('default device profile matches official-style bilibili renderer fields', () => {
+  const profile = createDeviceProfile({ ip: '192.168.1.2', httpPort: 9958 });
+  const xml = renderDescriptionXml(profile);
+
+  assert.match(xml, /<friendlyName>我的小电视<\/friendlyName>/);
+  assert.match(xml, /<X_brandName>ATV<\/X_brandName>/);
+  assert.match(xml, /<modelDescription>云视听小电视<\/modelDescription>/);
+});
+
+test('ssdp packets advertise media renderer and nirvana service', () => {
+  const profile = createDeviceProfile({ ip: '192.168.1.2', httpPort: 9958 });
+
+  const packets = getSsdpNotifyPackets(profile);
+  const joined = packets.join('\n---\n');
+
+  assert.match(joined, /NTS: ssdp:alive/);
+  assert.match(joined, /urn:schemas-upnp-org:device:MediaRenderer:1/);
+  assert.match(joined, /urn:app-bilibili-com:service:NirvanaControl:3/);
+});
+
+test('ssdp search response points to description xml', () => {
+  const profile = createDeviceProfile({ ip: '192.168.1.2', httpPort: 9958 });
+  const response = getSsdpSearchResponse(profile, 'urn:schemas-upnp-org:device:MediaRenderer:1');
+
+  assert.match(response, /HTTP\/1\.1 200 OK/);
+  assert.match(response, /LOCATION: http:\/\/192\.168\.1\.2:9958\/description\.xml/);
+  assert.match(response, /USN: uuid:atvbilibili&/);
+  assert.match(response, /ST: upnp:rootdevice/);
+});

--- a/service/com.biliwebos.app.service/test/device-profile.test.js
+++ b/service/com.biliwebos.app.service/test/device-profile.test.js
@@ -56,3 +56,13 @@ test('ssdp search response falls back to rootdevice when ST is empty', () => {
   assert.match(response, /ST: upnp:rootdevice/);
   assert.match(response, /USN: uuid:atvbilibili&[A-F0-9]+::upnp:rootdevice/);
 });
+
+test('ssdp:all search answers as rootdevice, never echoes the wildcard', () => {
+  const profile = createDeviceProfile({ ip: '192.168.1.2', httpPort: 9958 });
+  const response = getSsdpSearchResponse(profile, 'ssdp:all');
+
+  // Echoing "ssdp:all" as the ST/USN is invalid and made the Bilibili app
+  // ignore the device — it must answer with a concrete target.
+  assert.match(response, /ST: upnp:rootdevice/);
+  assert.doesNotMatch(response, /ssdp:all/);
+});

--- a/service/com.biliwebos.app.service/test/device-profile.test.js
+++ b/service/com.biliwebos.app.service/test/device-profile.test.js
@@ -56,13 +56,3 @@ test('ssdp search response falls back to rootdevice when ST is empty', () => {
   assert.match(response, /ST: upnp:rootdevice/);
   assert.match(response, /USN: uuid:atvbilibili&[A-F0-9]+::upnp:rootdevice/);
 });
-
-test('ssdp:all search answers as rootdevice, never echoes the wildcard', () => {
-  const profile = createDeviceProfile({ ip: '192.168.1.2', httpPort: 9958 });
-  const response = getSsdpSearchResponse(profile, 'ssdp:all');
-
-  // Echoing "ssdp:all" as the ST/USN is invalid and made the Bilibili app
-  // ignore the device — it must answer with a concrete target.
-  assert.match(response, /ST: upnp:rootdevice/);
-  assert.doesNotMatch(response, /ssdp:all/);
-});

--- a/service/com.biliwebos.app.service/test/nva-session.test.js
+++ b/service/com.biliwebos.app.service/test/nva-session.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  decodeFrame,
+  encodeEmptyReply,
+  encodeJsonReply,
+  encodeCommand,
+} = require('../cast/nvaSession');
+
+test('decode command frame with json body', () => {
+  const frame = Buffer.concat([
+    Buffer.from([0xe0, 0x03, 0x00, 0x00, 0x00, 0x02, 0x01, 0x07]),
+    Buffer.from('Command'),
+    Buffer.from([0x04]),
+    Buffer.from('Play'),
+    Buffer.from([0x00, 0x00, 0x00, 0x14]),
+    Buffer.from('{"aid":1,"cid":2}'),
+  ]);
+
+  const decoded = decodeFrame(frame);
+
+  assert.equal(decoded.type, 'command');
+  assert.equal(decoded.action, 'Play');
+  assert.equal(decoded.body, '{"aid":1,"cid":2}');
+  assert.equal(decoded.version, 2);
+});
+
+test('encode json reply and command frames', () => {
+  const reply = encodeJsonReply(3, { volume: 30 });
+  const command = encodeCommand(4, 'OnPlayState', { playState: 4 });
+
+  assert.equal(reply[0], 0xc0);
+  assert.equal(reply[1], 0x01);
+  assert.equal(command[0], 0xe0);
+  assert.equal(command[1], 0x03);
+});
+
+test('encode empty reply frame', () => {
+  const reply = encodeEmptyReply(7);
+
+  assert.deepEqual(Array.from(reply.subarray(0, 6)), [0xc0, 0x00, 0x00, 0x00, 0x00, 0x07]);
+});

--- a/tools/drive.mjs
+++ b/tools/drive.mjs
@@ -1,0 +1,94 @@
+// Drive the TV app via CDP: inject remote-control key events, then screenshot.
+// Usage: node tools/drive.mjs "<keys>" [outfile] [pass] [perKeyMs]
+//   keys: comma-separated — up,down,left,right,ok,back,home (home=many lefts)
+//   e.g. node tools/drive.mjs "down,down,right" up.png
+// Lets Claude operate + verify the app without a human.
+import { Client } from 'ssh2';
+import { readFileSync, writeFileSync } from 'fs';
+import http from 'http';
+import net from 'net';
+import { WebSocket } from 'ws';
+
+const TV = { host: '192.168.50.94', port: 9922 };
+const KEYSEQ = (process.argv[2] || '').split(',').map(s => s.trim()).filter(Boolean);
+const OUT = process.argv[3] || 'drive.png';
+const PASS = process.argv[4] || '4E7082';
+const PER_KEY_MS = parseInt(process.argv[5]) || 450;
+
+const KEYMAP = {
+  up: { key: 'ArrowUp', code: 'ArrowUp', vk: 38 },
+  down: { key: 'ArrowDown', code: 'ArrowDown', vk: 40 },
+  left: { key: 'ArrowLeft', code: 'ArrowLeft', vk: 37 },
+  right: { key: 'ArrowRight', code: 'ArrowRight', vk: 39 },
+  ok: { key: 'Enter', code: 'Enter', vk: 13 },
+  enter: { key: 'Enter', code: 'Enter', vk: 13 },
+  back: { key: 'Backspace', code: 'Backspace', vk: 8 },
+};
+
+const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+
+const conn = new Client();
+conn.on('ready', () => {
+  const server = net.createServer(s => {
+    conn.forwardOut('127.0.0.1', 0, '127.0.0.1', 9998, (err, rs) => {
+      if (err) { s.end(); return; } s.pipe(rs).pipe(s);
+    });
+  });
+  server.listen(19994, '127.0.0.1', () => {
+    http.get('http://127.0.0.1:19994/json', res => {
+      let d = ''; res.on('data', c => d += c);
+      res.on('end', async () => {
+        const app = JSON.parse(d).find(p => p.title?.includes('哔哩') || p.url?.includes('biliwebos'));
+        if (!app) { console.log('App not running'); process.exit(1); }
+        const ws = new WebSocket(app.webSocketDebuggerUrl.replace(/127\.0\.0\.1:\d+/, '127.0.0.1:19994'));
+        let id = 1;
+        const send = (method, params) => { ws.send(JSON.stringify({ id: id++, method, params: params || {} })); };
+        const call = (method, params) => new Promise(resolve => {
+          const myId = id;
+          send(method, params);
+          const h = (raw) => { const m = JSON.parse(raw); if (m.id === myId) { ws.off('message', h); resolve(m.result); } };
+          ws.on('message', h);
+        });
+
+        await new Promise(r => ws.on('open', r));
+        await call('Runtime.enable');
+
+        // Expand "home" → several lefts to get back to the sidebar
+        const seq = [];
+        for (const k of KEYSEQ) {
+          if (k === 'home') { for (let i = 0; i < 6; i++) seq.push('left'); }
+          else seq.push(k);
+        }
+
+        for (const k of seq) {
+          const m = KEYMAP[k];
+          if (!m) { console.log('unknown key: ' + k); continue; }
+          await call('Input.dispatchKeyEvent', { type: 'keyDown', key: m.key, code: m.code, windowsVirtualKeyCode: m.vk, nativeVirtualKeyCode: m.vk });
+          await call('Input.dispatchKeyEvent', { type: 'keyUp', key: m.key, code: m.code, windowsVirtualKeyCode: m.vk, nativeVirtualKeyCode: m.vk });
+          await sleep(PER_KEY_MS);
+        }
+
+        // Let the UI settle (loads/animations), then read state + screenshot.
+        await sleep(1200);
+        const diag = await call('Runtime.evaluate', { expression: `JSON.stringify({
+          focus: document.querySelector('.focused, [data-focus-id].focused')?.getAttribute('data-focus-id') || null,
+          v: (function(){var v=document.querySelector('video');return v?{t:+v.currentTime.toFixed(1),ready:v.readyState,paused:v.paused}:null;})(),
+          imgs: document.querySelectorAll('img').length,
+          brokenImgs: Array.from(document.querySelectorAll('img')).filter(i=>i.complete&&i.naturalWidth===0).length,
+        })`, returnByValue: true });
+        console.log('STATE: ' + (diag?.result?.value || 'n/a'));
+
+        const shot = await call('Page.captureScreenshot', { format: 'png' });
+        if (shot?.data) { writeFileSync(OUT, Buffer.from(shot.data, 'base64')); console.log('shot: ' + OUT); }
+        ws.close(); server.close(); conn.end(); process.exit(0);
+      });
+    });
+  });
+});
+conn.on('error', e => { console.error('SSH error:', e.message); process.exit(1); });
+conn.connect({
+  host: TV.host, port: TV.port, username: 'prisoner',
+  privateKey: readFileSync(process.env.HOME + '/.ssh/tv_webos'),
+  passphrase: PASS, algorithms: { serverHostKey: ['ssh-rsa'] },
+});
+setTimeout(() => { console.error('timeout'); process.exit(1); }, 60000);

--- a/tools/netcap.mjs
+++ b/tools/netcap.mjs
@@ -1,0 +1,90 @@
+// Capture network responses going through the local proxy (:7654) so we can
+// see the real CDN host + the proxy's HTTP status for each segment request.
+import { Client } from 'ssh2';
+import { readFileSync } from 'fs';
+import http from 'http';
+import net from 'net';
+
+const TV = { host: '192.168.50.94', port: 9922, user: 'prisoner' };
+const KEY = process.env.HOME + '/.ssh/tv_webos';
+const PASSPHRASE = process.argv[2] || '4E7082';
+const DURATION_MS = (parseInt(process.argv[3]) || 70) * 1000;
+const LOCAL_PORT = 19995;
+
+function ts() { return new Date().toISOString().slice(11, 19); }
+
+async function main() {
+  const conn = new Client();
+  await new Promise((resolve, reject) => {
+    conn.on('ready', resolve); conn.on('error', reject);
+    conn.connect({ host: TV.host, port: TV.port, username: TV.user,
+      privateKey: readFileSync(KEY), passphrase: PASSPHRASE,
+      algorithms: { serverHostKey: ['ssh-rsa'] } });
+  });
+  const server = net.createServer((s) => {
+    conn.forwardOut('127.0.0.1', LOCAL_PORT, '127.0.0.1', 9998, (err, rs) => {
+      if (err) { s.end(); return; } s.pipe(rs).pipe(s);
+    });
+  });
+  await new Promise(r => server.listen(LOCAL_PORT, '127.0.0.1', r));
+
+  const pages = await fetchJSON(`http://127.0.0.1:${LOCAL_PORT}/json`);
+  const appPage = pages.find(p => p.url?.includes('biliwebos') || p.title?.includes('哔哩'));
+  if (!appPage) { console.log('app page not found'); process.exit(1); }
+  const wsUrl = appPage.webSocketDebuggerUrl.replace(/127\.0\.0\.1:\d+/, `127.0.0.1:${LOCAL_PORT}`);
+  const { WebSocket } = await import('ws');
+  const ws = new WebSocket(wsUrl);
+  let id = 1;
+  const reqHost = {}; // requestId -> proxied host
+  const reqStart = {}; // requestId -> ms timestamp
+
+  ws.on('open', () => {
+    ws.send(JSON.stringify({ id: id++, method: 'Network.enable' }));
+    ws.send(JSON.stringify({ id: id++, method: 'Console.enable' }));
+    ws.send(JSON.stringify({ id: id++, method: 'Runtime.enable' }));
+    console.log(`[${ts()}] network+console capture ${DURATION_MS / 1000}s — retry the failing video now`);
+  });
+  ws.on('message', (data) => {
+    const msg = JSON.parse(data);
+    if (msg.method === 'Console.messageAdded') {
+      const m = msg.params?.message;
+      console.log(`[${ts()}] console.${m?.level}: ${m?.text}`);
+    }
+    if (msg.method === 'Runtime.exceptionThrown') {
+      console.log(`[${ts()}] EXCEPTION: ${msg.params?.exceptionDetails?.text}`);
+    }
+    if (msg.method === 'Network.requestWillBeSent') {
+      const url = msg.params?.request?.url || '';
+      if (url.includes('/proxy/')) {
+        const m = url.match(/\/proxy\/([^/]+)/);
+        reqHost[msg.params.requestId] = m ? m[1] : url.slice(0, 60);
+        reqStart[msg.params.requestId] = msg.params.timestamp * 1000; // s -> ms
+        const range = msg.params?.request?.headers?.Range || msg.params?.request?.headers?.range || '';
+        if (range) reqHost[msg.params.requestId] += ' ' + range;
+      }
+    }
+    if (msg.method === 'Network.loadingFinished') {
+      const host = reqHost[msg.params.requestId];
+      if (host) {
+        const dur = Math.round(msg.params.timestamp * 1000 - (reqStart[msg.params.requestId] || msg.params.timestamp * 1000));
+        const kb = Math.round((msg.params.encodedDataLength || 0) / 1024);
+        console.log(`[${ts()}] done ${dur}ms ${kb}KB ${host}`);
+      }
+    }
+    if (msg.method === 'Network.loadingFailed') {
+      const host = reqHost[msg.params.requestId];
+      if (host) console.log(`[${ts()}] FAILED ${host} — ${msg.params.errorText}`);
+    }
+  });
+
+  await new Promise(r => setTimeout(r, DURATION_MS));
+  ws.close(); server.close(); conn.end();
+  console.log(`[${ts()}] netcap done`); process.exit(0);
+}
+function fetchJSON(url) {
+  return new Promise((resolve, reject) => {
+    http.get(url, res => { let d = ''; res.on('data', c => d += c);
+      res.on('end', () => { try { resolve(JSON.parse(d)); } catch { reject(new Error('bad json')); } }); }).on('error', reject);
+  });
+}
+main().catch(e => { console.error('Fatal:', e.message); process.exit(1); });

--- a/tools/sh.mjs
+++ b/tools/sh.mjs
@@ -1,0 +1,24 @@
+// Run an arbitrary shell command on the TV over SSH and print its output.
+// Usage: node tools/sh.mjs "<command>" [passphrase]
+import { Client } from 'ssh2';
+import { readFileSync } from 'fs';
+
+const TV = { host: '192.168.50.94', port: 9922, user: 'prisoner' };
+const KEY = process.env.HOME + '/.ssh/tv_webos';
+const CMD = process.argv[2] || 'echo no-command';
+const PASSPHRASE = process.argv[3] || '4E7082';
+
+const conn = new Client();
+conn.on('ready', () => {
+  conn.exec(CMD, (err, stream) => {
+    if (err) { console.error(err.message); process.exit(1); }
+    stream.on('data', d => process.stdout.write(d));
+    stream.stderr.on('data', d => process.stderr.write(d));
+    stream.on('close', () => { conn.end(); process.exit(0); });
+  });
+}).on('error', e => { console.error('SSH error:', e.message); process.exit(1); })
+  .connect({
+    host: TV.host, port: TV.port, username: TV.user,
+    privateKey: readFileSync(KEY), passphrase: PASSPHRASE,
+    algorithms: { serverHostKey: ['ssh-rsa'] },
+  });

--- a/tools/watch.mjs
+++ b/tools/watch.mjs
@@ -1,0 +1,97 @@
+// Long-running log monitor for the TV app.
+// Captures console + runtime exceptions, timestamps each line, and flags
+// stall-related messages (Payload mismatch / Shaka error / watchdog / retry).
+import { Client } from 'ssh2';
+import { readFileSync } from 'fs';
+import http from 'http';
+import net from 'net';
+
+const TV = { host: '192.168.50.94', port: 9922, user: 'prisoner' };
+const KEY = process.env.HOME + '/.ssh/tv_webos';
+const PASSPHRASE = process.argv[2] || '4E7082';
+const DURATION_MS = (parseInt(process.argv[3]) || 300) * 1000;
+const REMOTE_DEBUG_PORT = 9998;
+const LOCAL_PORT = parseInt(process.argv[4]) || 19997;
+
+function ts() { return new Date().toISOString().slice(11, 19); }
+function flag(text) {
+  return /payload length|shaka error|watchdog|retrystreaming|stall|error|fail|fatal|buffer/i.test(text);
+}
+
+async function main() {
+  const conn = new Client();
+  await new Promise((resolve, reject) => {
+    conn.on('ready', resolve);
+    conn.on('error', reject);
+    conn.connect({
+      host: TV.host, port: TV.port, username: TV.user,
+      privateKey: readFileSync(KEY), passphrase: PASSPHRASE,
+      algorithms: { serverHostKey: ['ssh-rsa'] },
+    });
+  });
+
+  const server = net.createServer((localSocket) => {
+    conn.forwardOut('127.0.0.1', LOCAL_PORT, '127.0.0.1', REMOTE_DEBUG_PORT, (err, remoteStream) => {
+      if (err) { localSocket.end(); return; }
+      localSocket.pipe(remoteStream).pipe(localSocket);
+    });
+  });
+  await new Promise(r => server.listen(LOCAL_PORT, '127.0.0.1', r));
+
+  const pages = await fetchJSON(`http://127.0.0.1:${LOCAL_PORT}/json`);
+  const appPage = pages.find(p => p.url?.includes('biliwebos') || p.title?.includes('哔哩'));
+  if (!appPage) { console.log('App page not found'); process.exit(1); }
+
+  const wsUrl = appPage.webSocketDebuggerUrl.replace(/127\.0\.0\.1:\d+/, `127.0.0.1:${LOCAL_PORT}`);
+  const { WebSocket } = await import('ws');
+  const ws = new WebSocket(wsUrl);
+  let msgId = 1;
+
+  ws.on('open', () => {
+    ws.send(JSON.stringify({ id: msgId++, method: 'Console.enable' }));
+    ws.send(JSON.stringify({ id: msgId++, method: 'Runtime.enable' }));
+    console.log(`[${ts()}] monitoring for ${DURATION_MS / 1000}s — play a video now`);
+
+    // Poll playback position every 5s so we can see exactly when it freezes.
+    setInterval(() => {
+      ws.send(JSON.stringify({
+        id: 200, method: 'Runtime.evaluate',
+        params: { expression: `(function(){var v=document.querySelector('video');return v?JSON.stringify({t:+v.currentTime.toFixed(1),paused:v.paused,ended:v.ended,ready:v.readyState,buffered:v.buffered.length?+v.buffered.end(v.buffered.length-1).toFixed(1):0}):'no-video';})()` }
+      }));
+    }, 5000);
+  });
+
+  ws.on('message', (data) => {
+    const msg = JSON.parse(data);
+    if (msg.method === 'Console.messageAdded') {
+      const m = msg.params?.message;
+      const text = m?.text || '';
+      const mark = flag(text) ? ' <<<' : '';
+      console.log(`[${ts()}] console.${m?.level}: ${text}${mark}`);
+    }
+    if (msg.method === 'Runtime.exceptionThrown') {
+      const ex = msg.params?.exceptionDetails;
+      console.log(`[${ts()}] EXCEPTION: ${ex?.text} ${ex?.exception?.description || ''} <<<`);
+    }
+    if (msg.id === 200 && msg.result?.result?.value) {
+      console.log(`[${ts()}] video: ${msg.result.result.value}`);
+    }
+  });
+
+  ws.on('error', (e) => console.log(`[${ts()}] ws error: ${e.message}`));
+
+  await new Promise(r => setTimeout(r, DURATION_MS));
+  ws.close(); server.close(); conn.end();
+  console.log(`[${ts()}] monitor done`);
+  process.exit(0);
+}
+
+function fetchJSON(url) {
+  return new Promise((resolve, reject) => {
+    http.get(url, res => {
+      let d = ''; res.on('data', c => d += c);
+      res.on('end', () => { try { resolve(JSON.parse(d)); } catch { reject(new Error('Bad JSON')); } });
+    }).on('error', reject);
+  });
+}
+main().catch(e => { console.error('Fatal:', e.message); process.exit(1); });


### PR DESCRIPTION
Combined branch: all the playback/UX work from #8 **plus** the Bilibili native cast receiver from #3, merged and hardened. Verified on a real LG C4 (CDP self-driving for the app; a real iPhone Bilibili cast for the receiver).

## Playback (supersedes #8)
- **Freeze / load failures**: MPD carries backup CDN URLs and prefers stable origin (upos/`*.bilivideo.com`) over flaky PCDN (`*.mcdn.bilivideo.cn:8082`); load retries 3× with an error overlay instead of a black screen.
- **Slow loads (5-9s → <1s)**: removed an exponential retry backoff that added ~7.5s in the manifest-parser phase; resume via `load(url, startTime)`; single highest-bitrate rep (ABR off); local proxy keep-alive + 10s upstream timeout + forced `identity` on the binary path.
- Stall watchdog; quality pinning (no silent downgrade).

## Features
- Player bottom panel tabbed **相关推荐 / UP主投稿** (newest-first); upload time on cards; redesigned end screen (4-col grid + D-pad nav).
- Home **关注** offset-cursor pagination + newest-first sort; **已关注** badge; proxied/resized thumbnails.
- Restored missing `VideoRow.jsx`.

## Cast receiver (incorporates #3 by @dotennin)
- SSDP discovery + `description.xml` (MediaRenderer + AVTransport + NirvanaControl:3); NVA session handling; phone → TV takeover of playback.
- **Hardening**: SSDP `ssdp:alive` 1s→10s; TCP idle timeout + 64KB pre-header cap; NVA 4MB frame cap; M-SEARCH echoes the requested `st`.
- **Device name is dynamic**: `哔哩哔哩 on LG <model>` derived from the TV's `modelName` at runtime (not hardcoded); user rename via `castSetConfig` wins and applies live (no restart); `{reset:true}` reverts.

## Dev tools
- `tools/drive.mjs` (CDP key injection + screenshot + state), `netcap.mjs`, `watch.mjs`, `sh.mjs` for on-device driving/diagnosis without a human.

Closes #8. Incorporates and supersedes #3 (cast work credited to @dotennin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)