### PR TITLE
Fix video grid focus jumping off-screen on webOSShow more lines

### DIFF
--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -127,7 +127,6 @@ html, body, #root {
   cursor: pointer;
   outline: none;
   contain: content;
-  content-visibility: auto;
   transform: scale(1);
   transition: transform 0.15s ease;
 }


### PR DESCRIPTION
## Issue

When navigating through deeper rows of the video grid, the grid could suddenly jump ahead and move the focused video tile above the visible viewport.

The failure occurred at different row depths depending on whether the grid used 2, 3, or 4 columns.

## Cause

`content-visibility: auto` caused offscreen video-card geometry to become unstable while the grid was moved using `transform: translateY(...)`.

## Fix

Remove `content-visibility: auto` from `.video-card` while retaining `contain: content`.

## Testing

Tested on an LG OLED55CSPSA running webOS 22 with a clean build containing only this CSS change.

Verified:

- 2-column layout
- 3-column layout
- 4-column layout
- Deep downward and upward D-pad navigation
- Focus remains visible
- No automatic scrolling or multi-row jumps